### PR TITLE
add missing EventSelectAll

### DIFF
--- a/cegui/include/CEGUI/GUIContext.h
+++ b/cegui/include/CEGUI/GUIContext.h
@@ -274,6 +274,7 @@ protected:
     bool handleCursorActivateEvent(const SemanticInputEvent& event);
     bool handleCursorPressHoldEvent(const SemanticInputEvent& event);
     bool handleSelectWord(const SemanticInputEvent& event);
+    bool handleSelectAll(const SemanticInputEvent& event);
     bool handleUndoRequest(const SemanticInputEvent& event);
     bool handleRedoRequest(const SemanticInputEvent& event);
 

--- a/cegui/include/CEGUI/SemanticInputEvent.h
+++ b/cegui/include/CEGUI/SemanticInputEvent.h
@@ -97,6 +97,7 @@ enum class SemanticValue : int
     PointerDeactivate,
     CursorPressHold,
     CursorSelectWord,
+    CursorSelectAll,
     CursorMove,
     PointerLeave,
     SelectRange,

--- a/cegui/include/CEGUI/Window.h
+++ b/cegui/include/CEGUI/Window.h
@@ -454,6 +454,11 @@ public:
      * valid.
      */
     static const String EventSelectWord;
+    /** Event fired when the cursor is activated three times within the Window.
+     * Handlers are passed a const CursorInputEventArgs reference with all fields
+     * valid.
+     */
+    static const String EventSelectAll;
     /** Event fired when the cursor is activated within the Window.
      * Handlers are passed a const CursorInputEventArgs reference with all fields
      * valid.
@@ -3276,7 +3281,16 @@ protected:
         CursorInputEventArgs object.  All fields are valid.
     */
     virtual void onSelectWord(CursorInputEventArgs& e);
-    
+
+    /*!
+    \brief
+        Handler called when a cursor is activated three times within this window's area.
+
+    \param e
+        CursorInputEventArgs object.  All fields are valid.
+    */
+    virtual void onSelectAll(CursorInputEventArgs& e);
+
     /*!
     \brief
         Handler called when a cursor is activated within this window's area.

--- a/cegui/include/CEGUI/widgets/DefaultWindow.h
+++ b/cegui/include/CEGUI/widgets/DefaultWindow.h
@@ -87,6 +87,7 @@ protected:
     void onScroll(CursorInputEventArgs& e) override;
     void onCursorPressHold(CursorInputEventArgs& e) override;
     void onSelectWord(CursorInputEventArgs& e) override;
+    void onSelectAll(CursorInputEventArgs& e) override;
     void onCursorActivate(CursorInputEventArgs& e) override;
 
     void onSemanticInputEvent(SemanticEventArgs& e) override;

--- a/cegui/src/GUIContext.cpp
+++ b/cegui/src/GUIContext.cpp
@@ -732,6 +732,9 @@ void GUIContext::initializeSemanticEventHandlers()
     d_semanticEventHandlers.insert(std::make_pair(SemanticValue::SelectWord,
         new InputEventHandlerSlot<GUIContext, SemanticInputEvent>(
             &GUIContext::handleSelectWord, this)));
+    d_semanticEventHandlers.insert(std::make_pair(SemanticValue::SelectAll,
+        new InputEventHandlerSlot<GUIContext, SemanticInputEvent>(
+            &GUIContext::handleSelectAll, this)));
     d_semanticEventHandlers.insert(std::make_pair(SemanticValue::CursorMove,
         new InputEventHandlerSlot<GUIContext, SemanticInputEvent>(
             &GUIContext::handleCursorMoveEvent, this)));
@@ -816,6 +819,30 @@ bool GUIContext::handleSelectWord(const SemanticInputEvent& event)
         d_windowNavigator->setCurrentFocusedWindow(ciea.window);
 
     ciea.window->onSelectWord(ciea);
+    return ciea.handled != 0;
+}
+
+//----------------------------------------------------------------------------//
+bool GUIContext::handleSelectAll(const SemanticInputEvent& event)
+{
+    CursorInputEventArgs ciea(nullptr);
+    ciea.position = d_cursor.getPosition();
+    ciea.moveDelta = glm::vec2(0, 0);
+    ciea.source = event.d_payload.source;
+    ciea.scroll = 0;
+    ciea.window = getTargetWindow(ciea.position, false);
+    // make cursor position sane for this target window
+    if (ciea.window)
+        ciea.position = ciea.window->getUnprojectedPosition(ciea.position);
+
+    // if there is no target window, input can not be handled.
+    if (!ciea.window)
+        return false;
+
+    if (d_windowNavigator != nullptr)
+        d_windowNavigator->setCurrentFocusedWindow(ciea.window);
+
+    ciea.window->onSelectAll(ciea);
     return ciea.handled != 0;
 }
 

--- a/cegui/src/Window.cpp
+++ b/cegui/src/Window.cpp
@@ -139,6 +139,7 @@ const String Window::EventCursorLeavesSurface("CursorLeavesSurface");
 const String Window::EventCursorMove("CursorMove");
 const String Window::EventCursorPressHold("CursorPressHold");
 const String Window::EventSelectWord("SelectWord");
+const String Window::EventSelectAll("SelectAll");
 const String Window::EventCursorActivate("CursorActivate");
 const String Window::EventCharacterKey("CharacterKey");
 const String Window::EventScroll("Scroll");
@@ -2889,6 +2890,26 @@ void Window::onSelectWord(CursorInputEventArgs& e)
     {
         e.window = getParent();
         getParent()->onSelectWord(e);
+
+        return;
+    }
+
+    // by default we now mark cursor events as handled
+    // (derived classes may override, of course!)
+    ++e.handled;
+}
+
+//----------------------------------------------------------------------------//
+void Window::onSelectAll(CursorInputEventArgs& e)
+{
+    fireEvent(EventSelectAll, e, EventNamespace);
+
+    // optionally propagate to parent
+    if (!e.handled && d_propagatePointerInputs &&
+        d_parent && this != getGUIContext().getModalWindow())
+    {
+        e.window = getParent();
+        getParent()->onSelectAll(e);
 
         return;
     }

--- a/cegui/src/widgets/DefaultWindow.cpp
+++ b/cegui/src/widgets/DefaultWindow.cpp
@@ -78,6 +78,14 @@ void DefaultWindow::onSelectWord(CursorInputEventArgs& e)
 }
 
 //----------------------------------------------------------------------------//
+void DefaultWindow::onSelectAll(CursorInputEventArgs& e)
+{
+    // always call the base class handler
+    Window::onSelectAll(e);
+    updatePointerEventHandled(e);
+}
+
+//----------------------------------------------------------------------------//
 void DefaultWindow::onCursorActivate(CursorInputEventArgs& e)
 {
     // always call the base class handler


### PR DESCRIPTION
Hi! :tropical_drink:

fixes that the triple click cursor event is not marked as handled by default (triple click goes through windows)