### PR TITLE
Add tooltip boundaries

### DIFF
--- a/cegui/src/widgets/Tooltip.cpp
+++ b/cegui/src/widgets/Tooltip.cpp
@@ -120,6 +120,20 @@ namespace CEGUI
             tmpPos.y = cursor_pos.y - tipRect.getHeight() - 5;
         }
 
+        // prevent being cut off at the bottom and right edge
+        if (tmpPos.x + tipRect.getWidth() > screen.right())
+        {
+            tmpPos.x = screen.right() - tipRect.getWidth();
+        }
+        if (tmpPos.y + tipRect.getHeight() > screen.bottom())
+        {
+            tmpPos.y = screen.bottom() - tipRect.getHeight();
+        }
+
+        // prevent being cut off at the left and top edge
+        tmpPos.x = std::max(0.0f, tmpPos.x);
+        tmpPos.y = std::max(0.0f, tmpPos.y);
+
         // set final position of tooltip window.
         setPosition(
             UVector2(cegui_absdim(tmpPos.x),


### PR DESCRIPTION
to prevent them being cut off at the edges.

![72042305-b80acc80-32e0-11ea-9c2b-44830a2dd8b3](https://user-images.githubusercontent.com/215013/72092594-3ac57300-3345-11ea-999e-e6c244847dca.png)
(this was cut off at the top and left side before)