### PR TITLE
Fix compile errors, defective remove, wrong assignments, and memory leak

### DIFF
--- a/cegui/src/DefaultResourceProvider.cpp
+++ b/cegui/src/DefaultResourceProvider.cpp
@@ -228,9 +228,9 @@ size_t DefaultResourceProvider::getResourceGroupFileNames(
     struct android_app* app = AndroidUtils::getAndroidApp();
     AAssetDir* dirp;
 #if (CEGUI_STRING_CLASS != CEGUI_STRING_CLASS_UTF_32) 
-    if ((dirp == AAssetManager_openDir(app->activity->assetManager, dir_name.c_str()))) 
+    if ((dirp = AAssetManager_openDir(app->activity->assetManager, dir_name.c_str())))
 #else
-    if ((dirp == AAssetManager_openDir(app->activity->assetManager, String::convertUtf32ToUtf8(dir_name.getString()).c_str()))) 
+    if ((dirp = AAssetManager_openDir(app->activity->assetManager, String::convertUtf32ToUtf8(dir_name.getString()).c_str())))
 #endif
     {
         const char* filename;

--- a/cegui/src/ImageCodecModules/STB/stb_image.cpp
+++ b/cegui/src/ImageCodecModules/STB/stb_image.cpp
@@ -3298,7 +3298,8 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!tga_palette) {
+      if (!tga_palette)
+      {
          free(tga_data);
          return epuc("outofmem", "Out of memory");
       }

--- a/cegui/src/ImageCodecModules/STB/stb_image.cpp
+++ b/cegui/src/ImageCodecModules/STB/stb_image.cpp
@@ -3298,7 +3298,10 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!tga_palette) return epuc("outofmem", "Out of memory");
+      if (!tga_palette) {
+         free(tga_data);
+         return epuc("outofmem", "Out of memory");
+      }
       if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 )) {
          free(tga_data);
          free(tga_palette);

--- a/cegui/src/RendererModules/OpenGLES/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/OpenGLES/GeometryBuffer.cpp
@@ -137,7 +137,7 @@ void OpenGLESGeometryBuffer::appendGeometry(const Vertex* const vbuff,
     // buffer these vertices
     GLVertex vd;
     const Vertex* vs = vbuff;
-    for ((unsigned int i = 0; i < vertex_count; ++i, ++vs)
+    for (unsigned int i = 0; i < vertex_count; ++i, ++vs)
     {
         // copy vertex info the buffer, converting from CEGUI::Vertex to
         // something directly usable by OpenGLES as needed.
@@ -175,13 +175,13 @@ Texture* OpenGLESGeometryBuffer::getActiveTexture() const
 }
 
 //----------------------------------------------------------------------------//
-(unsigned int OpenGLESGeometryBuffer::getVertexCount() const
+unsigned int OpenGLESGeometryBuffer::getVertexCount() const
 {
     return d_vertices.size();
 }
 
 //----------------------------------------------------------------------------//
-(unsigned int OpenGLESGeometryBuffer::getBatchCount() const
+unsigned int OpenGLESGeometryBuffer::getBatchCount() const
 {
     return d_batches.size();
 }
@@ -189,7 +189,7 @@ Texture* OpenGLESGeometryBuffer::getActiveTexture() const
 //----------------------------------------------------------------------------//
 void OpenGLESGeometryBuffer::performBatchManagement()
 {
-    const GL(unsigned int gltex = d_activeTexture ?
+    const unsigned int gltex = d_activeTexture ?
                             d_activeTexture->getOpenGLESTexture() : 0;
 
     // create a new batch if there are no batches yet, or if the active texture

--- a/cegui/src/RendererModules/OpenGLES/RenderTarget.cpp
+++ b/cegui/src/RendererModules/OpenGLES/RenderTarget.cpp
@@ -144,7 +144,7 @@ void OpenGLESRenderTarget::unprojectPoint(const GeometryBuffer& buff,
     in_z = -d_viewDistance;
 
 	double gb_matrixd[16], d_matrixd[16];
-	for ((unsigned int i = 0; i < 16; ++i)
+	for (unsigned int i = 0; i < 16; ++i)
 	{
 		gb_matrixd[i] = (double)gb.getMatrix()[i];
 		d_matrixd[i] = (double)d_matrix[i];

--- a/cegui/src/falagard/WidgetComponent.cpp
+++ b/cegui/src/falagard/WidgetComponent.cpp
@@ -171,11 +171,18 @@ namespace CEGUI
 
     void WidgetComponent::removePropertyInitialiser(const String& name)
     {
-        for(PropertyInitialiserList::iterator i = d_propertyInitialisers.begin();
-                i < d_propertyInitialisers.end();
-                ++i)
-            if(i->getTargetPropertyName() == name)
-                d_propertyInitialisers.erase(i);
+        PropertyInitialiserList::iterator f = d_propertyInitialisers.begin();
+        PropertyInitialiserList::iterator const l = d_propertyInitialisers.end();
+        for(; f != l; ++f)
+            if(f->getTargetPropertyName() == name)
+                break;
+        if(f == l) return;
+        for(PropertyInitialiserList::iterator i = f; ++i != l;)
+            if(f->getTargetPropertyName() != name) {
+                *f = *i;
+                ++f;
+            }
+        d_propertyInitialisers.erase(f, l);
     }
 
     void WidgetComponent::clearPropertyInitialisers()

--- a/cegui/src/falagard/WidgetComponent.cpp
+++ b/cegui/src/falagard/WidgetComponent.cpp
@@ -173,15 +173,28 @@ namespace CEGUI
     {
         PropertyInitialiserList::iterator f = d_propertyInitialisers.begin();
         PropertyInitialiserList::iterator const l = d_propertyInitialisers.end();
+        // look for any removal candidate
         for(; f != l; ++f)
+        {
             if(f->getTargetPropertyName() == name)
+            {
                 break;
-        if(f == l) return;
+            }
+        }
+        if(f == l)
+        {
+            // nothing to remove, so done
+            return;
+        }
+        // start moving over any remaining items to keep
         for(PropertyInitialiserList::iterator i = f; ++i != l;)
-            if(f->getTargetPropertyName() != name) {
-                *f = *i;
+        {
+            if(f->getTargetPropertyName() != name)
+            {
+                std::iter_swap(f, i);
                 ++f;
             }
+        }
         d_propertyInitialisers.erase(f, l);
     }
 


### PR DESCRIPTION
* cegui/src/DefaultResourceProvider.cpp: Forgets to assign to `dirp` in `if`-statement.
* cegui/src/ImageCodecModules/STB/stb_image.cpp: Memory leak when `tga_palette` allocation fails.
* cegui/src/RendererModules/OpenGLES/GeometryBuffer.cpp and cegui/src/RendererModules/OpenGLES/RenderTarget.cpp: Unbalanced parenthesis.
* cegui/src/falagard/WidgetComponent.cpp: Incorrect and inefficient removal from a std::vector.