### PR TITLE
Fix memory leak and defective remove

### DIFF
--- a/cegui/src/ImageCodecModules/STB/stb_image.cpp
+++ b/cegui/src/ImageCodecModules/STB/stb_image.cpp
@@ -3298,7 +3298,10 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!tga_palette) return epuc("outofmem", "Out of memory");
+      if (!tga_palette) {
+         free(tga_data);
+         return epuc("outofmem", "Out of memory");
+      }
       if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 )) {
          free(tga_data);
          free(tga_palette);

--- a/cegui/src/XMLParserModules/TinyXML/XMLParser.cpp
+++ b/cegui/src/XMLParserModules/TinyXML/XMLParser.cpp
@@ -64,23 +64,20 @@ namespace CEGUI
         d_handler = &handler;
 
         // Create a buffer with extra bytes for a newline and a terminating null
-        size_t size = source.getSize();
-        char* buf = new char[size + 2];
-        memcpy(buf, source.getDataPtr(), size);
+        const size_t size = source.getSize();
+        std::string buf;
+        buf.reserve(size + 1);
+        buf.assign(source.getDataPtr(), size);
         // PDT: The addition of the newline is a kludge to resolve an issue
         // whereby parse returns 0 if the xml file has no newline at the end but
         // is otherwise well formed.
-        buf[size] = '\n';
-        buf[size+1] = 0;
+        buf += '\n';
 
         // Parse the document
         TiXmlDocument doc;
-        if (!doc.Parse(static_cast<const char*>(buf)))
+        if (!doc.Parse(buf.data()))
         {
-            // error detected, cleanup out buffers
-            delete[] buf;
-
-            // throw exception
+            // error detected, throw exception
             CEGUI_THROW(FileIOException("an error occurred while "
                 "parsing the XML document - check it for potential errors!."));
         }
@@ -88,21 +85,9 @@ namespace CEGUI
         const TiXmlElement* currElement = doc.RootElement();
         if (currElement)
         {
-            CEGUI_TRY
-            {
-                // function called recursively to parse xml data
-                processElement(currElement);
-            }
-            CEGUI_CATCH(...)
-            {
-                delete [] buf;
-
-                CEGUI_RETHROW;
-            }
-        } // if (currElement)
-
-        // Free memory
-        delete [] buf;
+            // function called recursively to parse xml data
+            processElement(currElement);
+        }
     }
 
     void TinyXMLDocument::processElement(const TiXmlElement* element)

--- a/cegui/src/falagard/WidgetComponent.cpp
+++ b/cegui/src/falagard/WidgetComponent.cpp
@@ -188,10 +188,11 @@ namespace CEGUI
     void WidgetComponent::removePropertyInitialiser(const String& name)
     {
         for(PropertiesList::iterator i = d_properties.begin();
-                i < d_properties.end();
-                ++i)
+                i != d_properties.end();)
             if(i->getTargetPropertyName() == name)
-                d_properties.erase(i);
+                i = d_properties.erase(i);
+            else
+                ++i;
     }
 
     void WidgetComponent::clearPropertyInitialisers()


### PR DESCRIPTION
Also, some robustness with less try-catch in XML-parser.

Assuming `<string>` available in `XMLParser.cpp`.