### PR TITLE
src/Exceptions.cpp: check if execinfo header is available

### DIFF
--- a/cegui/src/Exceptions.cpp
+++ b/cegui/src/Exceptions.cpp
@@ -42,7 +42,9 @@
 #elif     (defined(__linux__) && !defined(__ANDROID__)) \
       ||  defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) \
       ||  defined(__HAIKU__)
+#ifdef HAVE_EXECINFO_H
 #   include <execinfo.h>
+#endif
 #   include <dlfcn.h>
 #   include <cxxabi.h>
 #   include <cstdlib>


### PR DESCRIPTION
Fixes:
  fatal error: execinfo.h: No such file or directory
  compilation terminated.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>