### PR TITLE
[v0-8]cegui/src/IconvStringTranscoder.cpp: use cast notation instead of reinterpret_cast             

### DIFF
--- a/cegui/src/IconvStringTranscoder.cpp
+++ b/cegui/src/IconvStringTranscoder.cpp
@@ -47,7 +47,7 @@ public:
         d_toCode(tocode),
         d_cd(iconv_open(d_toCode.c_str(), d_fromCode.c_str()))
     {
-        if (d_cd == reinterpret_cast<iconv_t>(-1))
+        if (d_cd == (iconv_t)(-1))
             CEGUI_THROW(InvalidRequestException(String(
                 "Failed to create conversion descriptor from \"") +
                 d_fromCode.c_str() + "\" to \"" + d_toCode.c_str() + "\"."));


### PR DESCRIPTION
Fixes:
	IconvStringTranscoder.cpp:50:49: error: invalid cast from type 'int' to
	type 'iconv_t' {aka 'long int'}
         if (d_cd == reinterpret_cast<iconv_t>(-1))

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>