### PR TITLE
Fix debug build and rework Exceptions includes logic

### DIFF
--- a/cegui/src/Exceptions.cpp
+++ b/cegui/src/Exceptions.cpp
@@ -34,24 +34,24 @@
 
 #if defined( __WIN32__ ) || defined( _WIN32)
 #   include <windows.h>
+#elif defined(__ANDROID__)
+#   include <android/log.h>
 #endif
 
+#if defined(_DEBUG) || defined(DEBUG)
 #if defined(_MSC_VER)
 #   pragma warning(push)
 #   pragma warning(disable : 4091)
 #   include <dbghelp.h>
 #   pragma warning(pop)
-#elif defined(__ANDROID__)
-#   include <android/log.h>
 #elif     (defined(__linux__) && !defined(__ANDROID__)) \
       ||  defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) \
       ||  defined(__HAIKU__)
-#ifdef HAVE_EXECINFO_H
 #   include <execinfo.h>
-#endif
 #   include <dlfcn.h>
 #   include <cxxabi.h>
 #   include <cstddef>
+#endif
 #endif
 
 // Start of CEGUI namespace section
@@ -63,14 +63,6 @@ bool Exception::d_stdErrEnabled(true);
 //----------------------------------------------------------------------------//
 static void dumpBacktrace(size_t frames)
 {
-
-#if defined(__ANDROID__)
-
-    // Not implemented yet.
-    CEGUI_UNUSED(frames);
-
-#else
-
 #if defined(_DEBUG) || defined(DEBUG)
 #if defined(_MSC_VER)
     SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_INCLUDE_32BIT_MODULES);
@@ -214,8 +206,6 @@ static void dumpBacktrace(size_t frames)
 #else
 
     CEGUI_UNUSED(frames);
-
-#endif
 
 #endif
 }


### PR DESCRIPTION
Commit e18e48624cd4 broke the debug build. `HAVE_EXECINFO_H` is never defined by the build system so this header is never included, even when it is needed by the debug code.

The right way to fix this is only to include these headers when debug is actually enabled. This does mean that the debug build is still broken under musl but fixing that would require using libunwind instead.