### PR TITLE
Fix debug build and rework Exceptions includes logic (v0-8)

### DIFF
--- a/cegui/src/Exceptions.cpp
+++ b/cegui/src/Exceptions.cpp
@@ -33,21 +33,21 @@
 
 #if defined( __WIN32__ ) || defined( _WIN32)
 #   include <windows.h>
-#endif
-
-#if defined(_MSC_VER)
-#   include <dbghelp.h>
 #elif defined(__ANDROID__)
 #   include <android/log.h>
+#endif
+
+#if defined(_DEBUG) || defined(DEBUG)
+#if defined(_MSC_VER)
+#   include <dbghelp.h>
 #elif     (defined(__linux__) && !defined(__ANDROID__)) \
       ||  defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) \
       ||  defined(__HAIKU__)
-#ifdef HAVE_EXECINFO_H
 #   include <execinfo.h>
-#endif
 #   include <dlfcn.h>
 #   include <cxxabi.h>
 #   include <cstdlib>
+#endif
 #endif
 
 // Start of CEGUI namespace section
@@ -59,14 +59,6 @@ bool Exception::d_stdErrEnabled(true);
 //----------------------------------------------------------------------------//
 static void dumpBacktrace(size_t frames)
 {
-
-#if defined(__ANDROID__)
-
-    // Not implemented yet.
-    CEGUI_UNUSED(frames);
-
-#else
-
 #if defined(_DEBUG) || defined(DEBUG)
 #if defined(_MSC_VER)
     SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_INCLUDE_32BIT_MODULES);
@@ -188,8 +180,6 @@ static void dumpBacktrace(size_t frames)
 #else
 
     CEGUI_UNUSED(frames);
-
-#endif
 
 #endif
 }


### PR DESCRIPTION
Commit 3ddf92058392 broke the debug build. `HAVE_EXECINFO_H` is never defined by the build system so this header is never included, even when it is needed by the debug code.

The right way to fix this is only to include these headers when debug is actually enabled. This does mean that the debug build is still broken under musl but fixing that would require using libunwind instead.