### PR TITLE
SWIG fixes

### DIFF
--- a/cegui/include/CEGUI/Window.h
+++ b/cegui/include/CEGUI/Window.h
@@ -658,6 +658,7 @@ public:
     */
     bool isChild(unsigned int ID) const;
 
+    using NamedElement::isChildRecursive;
     /*!
     \brief
         returns whether at least one window with the given ID code is attached

--- a/cegui/src/ScriptModules/SWIG/CEGUI.i
+++ b/cegui/src/ScriptModules/SWIG/CEGUI.i
@@ -238,7 +238,6 @@ using namespace CEGUI;
 %include "CEGUI/widgets/ListWidget.h"
 
 %include "CEGUI/widgets/LayoutContainer.h"
-%include "CEGUI/widgets/SequentialLayoutContainer.h"
 %include "CEGUI/widgets/GridLayoutContainer.h"
 %include "CEGUI/widgets/HorizontalLayoutContainer.h"
 %include "CEGUI/widgets/VerticalLayoutContainer.h"
@@ -289,7 +288,6 @@ WINDOW_CONVERTER(MenuBase)
 WINDOW_CONVERTER(ListWidget)
 
 WINDOW_CONVERTER(LayoutContainer)
-WINDOW_CONVERTER(SequentialLayoutContainer)
 WINDOW_CONVERTER(GridLayoutContainer)
 WINDOW_CONVERTER(HorizontalLayoutContainer)
 WINDOW_CONVERTER(VerticalLayoutContainer)


### PR DESCRIPTION
* fix build after remove SequentialLayoutContainer
* now is possible use name based `isChildRecursive` version on Window objects (C++ interface need this too ...)