### PR TITLE
Bugfix for issue: "Window clipping not working in Ogre 2.1 renderer"

### DIFF
--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -110,6 +110,13 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
     {
     #ifdef CEGUI_USE_OGRE_HLMS
         setScissorRects(currentViewport);
+		
+		// if needed clear and re-set viewport to have ogre apply the acual scissor settings
+		if(!currentViewport->coversEntireTarget())
+		{
+			d_renderSystem._setViewport(NULL);
+			d_renderSystem._setViewport(currentViewport);
+		}
     #else
         setScissorRects();
     #endif //CEGUI_USE_OGRE_HLMS
@@ -373,8 +380,27 @@ void OgreGeometryBuffer::setScissorRects(Ogre::Viewport* current_viewport) const
     float scissorsHeight = (d_preparedClippingRegion.bottom() -
         d_preparedClippingRegion.top()) / actualHeight;
     
+
+	if(scissorsLeft > 0.1f)
+	{
+		int x = 43;
+		scissorsLeft = scissorsLeft;
+	}
+
+	if(scissorsLeft == 0.0f)
+	{
+		int x = 43;
+		scissorsLeft = scissorsLeft;
+	}
+
     current_viewport->setScissors(scissorsLeft, scissorsTop, scissorsWidth,
         scissorsHeight);
+
+	bool coversEntireScreen = current_viewport->coversEntireTarget();
+	if(coversEntireScreen)
+		coversEntireScreen = coversEntireScreen;
+
+	coversEntireScreen = coversEntireScreen;
 }
 
 #else

--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -177,6 +177,10 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
         currentViewport->setScissors(previousClipRect.left(), previousClipRect.top(),
             previousClipRect.right(), previousClipRect.bottom());
         // Restore viewport? d_renderSystem._setViewport(previousViewport);
+		
+		// clear and re-set viewport to have ogre apply the previous scissor settings
+		d_renderSystem._setViewport(NULL);
+		d_renderSystem._setViewport(currentViewport);
     #else
         d_renderSystem.setScissorTest(false);
     #endif //CEGUI_USE_OGRE_HLMS

--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -380,27 +380,8 @@ void OgreGeometryBuffer::setScissorRects(Ogre::Viewport* current_viewport) const
     float scissorsHeight = (d_preparedClippingRegion.bottom() -
         d_preparedClippingRegion.top()) / actualHeight;
     
-
-	if(scissorsLeft > 0.1f)
-	{
-		int x = 43;
-		scissorsLeft = scissorsLeft;
-	}
-
-	if(scissorsLeft == 0.0f)
-	{
-		int x = 43;
-		scissorsLeft = scissorsLeft;
-	}
-
     current_viewport->setScissors(scissorsLeft, scissorsTop, scissorsWidth,
         scissorsHeight);
-
-	bool coversEntireScreen = current_viewport->coversEntireTarget();
-	if(coversEntireScreen)
-		coversEntireScreen = coversEntireScreen;
-
-	coversEntireScreen = coversEntireScreen;
 }
 
 #else

--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -111,12 +111,9 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
     #ifdef CEGUI_USE_OGRE_HLMS
         setScissorRects(currentViewport);
 		
-		// if needed clear and re-set viewport to have ogre apply the acual scissor settings
-		if(!currentViewport->coversEntireTarget())
-		{
-			d_renderSystem._setViewport(NULL);
-			d_renderSystem._setViewport(currentViewport);
-		}
+		// clear and re-set viewport to have ogre apply the actual scissor settings
+		d_renderSystem._setViewport(NULL);
+		d_renderSystem._setViewport(currentViewport);
     #else
         setScissorRects();
     #endif //CEGUI_USE_OGRE_HLMS


### PR DESCRIPTION
Bugfix for issue: "Window clipping not working in Ogre 2.1 renderer"