### PR TITLE
cegui/src/Window.cpp

### DIFF
--- a/cegui/src/Window.cpp
+++ b/cegui/src/Window.cpp
@@ -3846,6 +3846,9 @@ Window* Window::clone(const bool deepCopy) const
     Window* ret =
         WindowManager::getSingleton().createWindow(getType(), getName());
 
+    //Setting some properties on DragContainer trigger events that require the GUI Context to be set
+    if (this->d_guiContext)
+        ret->setGUIContext(this->d_guiContext);
     // always copy properties
     clonePropertiesTo(*ret);
 


### PR DESCRIPTION
Setting GUIContext before copying properties as some properties trigger events that require GUIContext to be set