### PR TITLE
pkgconfig: Fix private dependency of OpenGL renderer

### DIFF
--- a/cegui/CEGUI-OPENGL.pc.in
+++ b/cegui/CEGUI-OPENGL.pc.in
@@ -9,4 +9,5 @@ Name: CEGUI-@CEGUI_VERSION_MAJOR@ OpenGL Renderer
 Description: OpenGL based renderer module for CEGUI.
 Version: @CEGUI_VERSION@
 Requires: CEGUI-@CEGUI_VERSION_MAJOR@ = @CEGUI_VERSION@
+Requires.private: glew
 Libs: -l@CEGUI_OPENGL_RENDERER_LIBNAME@


### PR DESCRIPTION
The old OpenGL renderer (not GL3) requires GLEW in the headers,
so add GLEW as a private requirement inside the pkgconfig file.