### PR TITLE
GLES: Fix library names to look for

### DIFF
--- a/cmake/FindOpenGLES.cmake
+++ b/cmake/FindOpenGLES.cmake
@@ -7,7 +7,7 @@
 include(FindPackageHandleStandardArgs)
 
 find_path(OPENGLES_H_PATH NAMES GLES/gl.h)
-find_library(OPENGLES_LIB NAMES GLES_CM)
+find_library(OPENGLES_LIB NAMES GLES_CM GLESv1_CM)
 mark_as_advanced(OPENGLES_H_PATH OPENGLES_LIB OPENGLES_LIB_DBG)
 
 find_package_handle_standard_args(OPENGLES DEFAULT_MSG OPENGLES_LIB OPENGLES_H_PATH)


### PR DESCRIPTION
Already fixed in master, but for v0 branch CMake is still
not searching all commonly used library names