### PR TITLE
fix rotation is not applied anymore when loading from XML

### DIFF
--- a/cegui/src/Window.cpp
+++ b/cegui/src/Window.cpp
@@ -3546,6 +3546,8 @@ void Window::allocateRenderingWindow(bool addStencilBuffer)
     static_cast<RenderingWindow*>(d_surface)->setSize(getPixelSize());
     static_cast<RenderingWindow*>(d_surface)->
         setPosition(getUnclippedOuterRect().get().getPosition());
+    static_cast<RenderingWindow*>(d_surface)->setRotation(d_rotation);
+    updatePivot();
 
     GUIContext* context = getGUIContextPtr();
     if (context)
@@ -3628,6 +3630,11 @@ void Window::initialiseClippers(const RenderingContext& ctx)
 void Window::onRotated(ElementEventArgs& e)
 {
     Element::onRotated(e);
+    
+    if(!getGUIContextPtr())
+    {
+        return;
+    }
 
     // TODO: Checking quaternion for equality with IDENTITY is stupid,
     //       change this to something else, checking with tolerance.


### PR DESCRIPTION
See #1176 

Rotation is now also set in Window::allocateRenderingWindow() as the d_surface is created after Window::onRotated().

The Window::onRotated() getGUIContextPtr() check is so the "Failed to obtain a suitable ReneringWindow surface for Window" is not triggered with loadLayoutFromFile() anymore.

@niello Maybe take a look too. I think this broke with the "Default context removed" changes. Thx!

