### PR TITLE
XMLParser.cpp: include string.h

### DIFF
--- a/cegui/src/XMLParserModules/RapidXML/XMLParser.cpp
+++ b/cegui/src/XMLParserModules/RapidXML/XMLParser.cpp
@@ -38,6 +38,8 @@
 #include "CEGUI/Logger.h"
 #include "CEGUI/Exceptions.h"
 
+#include <string.h>
+
 // Start of CEGUI namespace section
 namespace CEGUI
 {


### PR DESCRIPTION
Include `string.h` to avoid the following build failure:

```
/home/buildroot/autobuild/run/instance-3/output-1/build/cegui-00b4e1fe174da53b7ed726ab5970ba51bd5b5ee0/cegui/src/XMLParserModules/RapidXML/XMLParser.cpp:73:5: error: 'memcpy' was not declared in this scope
   73 |     memcpy(buf, source.getDataPtr(), size);
      |     ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/1cb09e5f52435efc505c61707b2d5d2ee871524b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>