### PR TITLE
OpenGLES/Renderer: add missing string.h

### DIFF
--- a/cegui/src/RendererModules/OpenGLES/Renderer.cpp
+++ b/cegui/src/RendererModules/OpenGLES/Renderer.cpp
@@ -39,6 +39,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <string.h>
 
 #include "CEGUI/RendererModules/OpenGLES/FBOTextureTarget.h"
 


### PR DESCRIPTION
Include missing string.h to avoid the following build failure:

/tmp/instance-6/output-1/build/cegui-00b4e1fe174da53b7ed726ab5970ba51bd5b5ee0/cegui/src/RendererModules/OpenGLES/Renderer.cpp:194:24: error: 'strlen' was not declared in this scope
  194 |   terminator = where + strlen(extension);

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>