### PR TITLE
String.h: missing include

### DIFF
--- a/cegui/include/CEGUI/String.h
+++ b/cegui/include/CEGUI/String.h
@@ -31,6 +31,7 @@
 #define _String_h_
 
 #include "CEGUI/Base.h"
+#include <stdexcept>
 
 #if (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_8) || (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_32)
 


### PR DESCRIPTION
Needed for std::out_of_range

https://en.cppreference.com/w/cpp/error/out_of_range