### PR TITLE
OgreRenderer - Support for Ogre 2.3

### DIFF
--- a/cegui/include/CEGUI/RendererModules/Ogre/ImageCodec.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/ImageCodec.h
@@ -30,6 +30,8 @@
 #include "../../ImageCodec.h"
 #include "CEGUI/RendererModules/Ogre/Renderer.h"
 
+#ifdef CEGUI_OGRE_NEXT
+
 // Start of CEGUI namespace section
 namespace CEGUI
 {
@@ -78,5 +80,58 @@ protected:
 };
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "../../ImageCodec.h"
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
 
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	/*!
+	\brief
+		ImageCodec object that loads data via image loading facilities in Ogre.
+	*/
+	class OGRE_GUIRENDERER_API OgreImageCodec : public ImageCodec
+	{
+	public:
+		//! Constructor.
+		OgreImageCodec();
+
+		/*!
+		\brief
+			Set the file-type identifier that will be used for future load
+			operations.
+
+			This allows us to pass the type on to Ogre when we process the image
+			data (because it's just file data; we do not have a filename nor file
+			extension).  Ogre needs this sometimes in order to correctly select the
+			right codec to use for the final decoding of the data.  If this value
+			is not set, loading may still succeed, though that will depend upon the
+			specific libraries and codecs that the Ogre installation has available
+			to it.
+
+		\param type
+			String object that describes the type of file data that will be passed
+			in subsequent load operations.  Note that this type will typically be
+			the file extension (or equivalent).
+		*/
+		void setImageFileDataType(const String& type);
+
+		/*!
+		\brief
+			Return the string descibing the currently set file type.
+		*/
+		const String& getImageFileDataType() const;
+
+		// implement required function from ImageCodec.
+		Texture* load(const RawDataContainer& data, Texture* result);
+
+	protected:
+		//! Holds currently set file data type specifier (i.e. the file extension).
+		String d_dataTypeID;
+	};
+
+} // End of  CEGUI namespace section
+
+#endif	//CEGUI_OGRE_NEXT
 #endif  // end of guard _CEGUIOgreImageCodec_h_

--- a/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget.h
@@ -27,8 +27,10 @@
 #ifndef _CEGUIOgreRenderTarget_h_
 #define _CEGUIOgreRenderTarget_h_
 
-#include "CEGUI/RenderTarget.h"
 #include "CEGUI/RendererModules/Ogre/Renderer.h"
+
+#ifdef CEGUI_OGRE_NEXT
+#include "CEGUI/RenderTarget.h"
 #include "CEGUI/Rectf.h"
 #include <OgreMatrix4.h>
 
@@ -40,26 +42,11 @@ class OGRE_GUIRENDERER_API OgreRenderTarget : virtual public RenderTarget
 {
 public:
     //! Constructor
-    OgreRenderTarget(OgreRenderer& owner, Ogre::RenderSystem& rs);
+    OgreRenderTarget(OgreRenderer& owner, Ogre::RenderSystem& rs, bool clearTextureBeforeRendering);
 
     //! Destructor
     virtual ~OgreRenderTarget();
     
-    /*!
-    \brief
-        Set the underlying viewport area directly - bypassing what the
-        RenderTarget considers to be it's area - thus allowing the view port
-        area used for rendering to be different to the area set for the target.
-
-    \param area
-        Rect object describing the area to use in pixels.
-
-    \deprecated
-        This function is deprecated and will be removed or changed considerably
-        in future releases.
-    */
-    void setOgreViewportDimensions(const Rectf& area);
-
     // implement parts of CEGUI::RenderTarget interface
     void draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask = DrawModeMaskAll);
     void draw(const RenderQueue& queue, std::uint32_t drawModeMask = DrawModeMaskAll);
@@ -71,32 +58,113 @@ public:
     // implementing the virtual function with a covariant return type
     virtual OgreRenderer& getOwner();
 
+	// setup the RenderPassDescriptors to be used
+	void updateRenderPassDescriptor();
+	Ogre::RenderPassDescriptor* getRenderPassDescriptorForFirstDraw() const { return d_renderPassDescForFirstDraw; }
+	Ogre::RenderPassDescriptor* getRenderPassDescriptorForAddionalDraw() const { return d_renderPassDescForAddionalDraw; }
+	
+	//! returns the TextureGpu
+	Ogre::TextureGpu* getTextureGpuTarget() const { return d_textureGpuTarget; }
+
+	//! return the viewport size to be used
+	Ogre::Vector4 getViewportSize() const {	return d_viewportSize; }
+
 protected:
     //! helper that initialises the cached matrix
     void updateMatrix() const;
-    //! helper that initialises the viewport
-    void updateViewport();
-    //! helper to update the actual Ogre viewport dimensions
-    void updateOgreViewportDimensions(const Ogre::RenderTarget* const rt);
+    
+	//! sets the viewport are to be used
+	void setOgreViewportDimensions(const Rectf& area);
 
     //! OgreRenderer object that owns this RenderTarget
     OgreRenderer& d_owner;
     //! Ogre RendererSystem used to affect the rendering process
     Ogre::RenderSystem& d_renderSystem;
     //! Ogre render target that we are effectively wrapping
-    Ogre::RenderTarget* d_renderTarget;
+    Ogre::TextureGpu* d_textureGpuTarget;
 
-    //! Ogre viewport used for this target.
-    Ogre::Viewport* d_viewport;
-    //! holds set Ogre viewport dimensions
-    Rectf d_ogreViewportDimensions;
+	//! Ogre RenderPassDescriptor we use for drawing
+	Ogre::RenderPassDescriptor* d_renderPassDescForFirstDraw;
+	Ogre::RenderPassDescriptor* d_renderPassDescForAddionalDraw;
+	//! secifies if the texture shall be cleared on frist draw of the GeometryBuffer in a queue. I.e. RenderTargets shall clear, but Windows where we draw on top and are cleard each frame shall not be cleared
+	bool d_clearTextureBeforeRendering;
 
-    //! true when d_viewport is up to date and valid.
-    //! \version Beginning from Ogre 2.0 this indicates whether the workspace is
-    //! up to date
-    bool d_viewportValid;
+	//! holds set Ogre viewport dimensions (in Ogre Format) which is send to the GemoetryBuffer
+	Ogre::Vector4 d_viewportSize;
 };
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RenderTarget.h"
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#include "CEGUI/Rectf.h"
+#include <OgreMatrix4.h>
 
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	//! Intermediate RenderTarget implementing common parts for Ogre engine.
+	class OGRE_GUIRENDERER_API OgreRenderTarget : virtual public RenderTarget
+	{
+	public:
+		//! Constructor
+		OgreRenderTarget(OgreRenderer& owner, Ogre::RenderSystem& rs);
+
+		//! Destructor
+		virtual ~OgreRenderTarget();
+
+		/*!
+		\brief
+			Set the underlying viewport area directly - bypassing what the
+			RenderTarget considers to be it's area - thus allowing the view port
+			area used for rendering to be different to the area set for the target.
+
+		\param area
+			Rect object describing the area to use in pixels.
+
+		\deprecated
+			This function is deprecated and will be removed or changed considerably
+			in future releases.
+		*/
+		void setOgreViewportDimensions(const Rectf& area);
+
+		// implement parts of CEGUI::RenderTarget interface
+		void draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask = DrawModeMaskAll);
+		void draw(const RenderQueue& queue, std::uint32_t drawModeMask = DrawModeMaskAll);
+
+		void activate();
+		void unprojectPoint(const GeometryBuffer& buff, const glm::vec2& p_in, glm::vec2& p_out) const;
+
+		virtual void setArea(const Rectf& area);
+		// implementing the virtual function with a covariant return type
+		virtual OgreRenderer& getOwner();
+
+	protected:
+		//! helper that initialises the cached matrix
+		void updateMatrix() const;
+		//! helper that initialises the viewport
+		void updateViewport();
+		//! helper to update the actual Ogre viewport dimensions
+		void updateOgreViewportDimensions(const Ogre::RenderTarget* const rt);
+
+		//! OgreRenderer object that owns this RenderTarget
+		OgreRenderer& d_owner;
+		//! Ogre RendererSystem used to affect the rendering process
+		Ogre::RenderSystem& d_renderSystem;
+		//! Ogre render target that we are effectively wrapping
+		Ogre::RenderTarget* d_renderTarget;
+
+		//! Ogre viewport used for this target.
+		Ogre::Viewport* d_viewport;
+		//! holds set Ogre viewport dimensions
+		Rectf d_ogreViewportDimensions;
+
+		//! true when d_viewport is up to date and valid.
+		//! \version Beginning from Ogre 2.0 this indicates whether the workspace is
+		//! up to date
+		bool d_viewportValid;
+	};
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT
 #endif  // end of guard _CEGUIOgreRenderTarget_h_

--- a/cegui/include/CEGUI/RendererModules/Ogre/ShaderWrapper.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/ShaderWrapper.h
@@ -27,8 +27,10 @@
 #ifndef _CEGUIOgreShaderWrapper_h_
 #define _CEGUIOgreShaderWrapper_h_
 
-#include <string>
 #include "Renderer.h"
+#ifdef CEGUI_OGRE_NEXT
+#include <string>
+
 #include "CEGUI/ShaderWrapper.h"
 #include "OgreHighLevelGpuProgram.h"
 
@@ -56,11 +58,8 @@ public:
 
     //Implementation of ShaderWrapper interface
     void prepareForRendering(const ShaderParameterBindings* shaderParameterBindings);
-
-    #ifdef CEGUI_USE_OGRE_HLMS
-    void setRenderOperation(const Ogre::v1::RenderOperation &operation);
-	#endif
-
+	void setRenderOperation(const Ogre::v1::RenderOperation &operation);
+	
     Ogre::GpuProgramParametersSharedPtr getVertexParameters() const;
 
 protected:
@@ -82,10 +81,8 @@ protected:
     //! Parameters for pixel shader
     Ogre::GpuProgramParametersSharedPtr d_pixelParameters;
 
-    #ifdef CEGUI_USE_OGRE_HLMS
     Ogre::v1::RenderOperation d_renderOp;
-	#endif
-
+	
     //! The currently active matrix
     glm::mat4 d_lastMatrix;
 
@@ -101,6 +98,80 @@ protected:
 };
 
 }
+#else	//CEGUI_OGRE_NEXT
+#include <string>
+#include "Renderer.h"
+#include "CEGUI/ShaderWrapper.h"
+#include "OgreHighLevelGpuProgram.h"
 
+#include "glm/glm.hpp"
+
+#if defined(_MSC_VER)
+#   pragma warning(push)
+#   pragma warning(disable : 4251)
+#endif
+
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	class ShaderParameterBindings;
+	class ShaderParameter;
+
+	//----------------------------------------------------------------------------//
+	class OGRE_GUIRENDERER_API OgreShaderWrapper : public ShaderWrapper
+	{
+	public:
+		OgreShaderWrapper(OgreRenderer& owner, Ogre::RenderSystem& rs,
+			Ogre::HighLevelGpuProgramPtr vs, Ogre::HighLevelGpuProgramPtr ps);
+
+		~OgreShaderWrapper();
+
+		//Implementation of ShaderWrapper interface
+		void prepareForRendering(const ShaderParameterBindings* shaderParameterBindings);
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		void setRenderOperation(const Ogre::v1::RenderOperation &operation);
+#endif
+
+		Ogre::GpuProgramParametersSharedPtr getVertexParameters() const;
+
+	protected:
+
+		//! Renderer object that owns this GeometryBuffer
+		OgreRenderer& d_owner;
+		//! Ogre render system we're to use.
+		Ogre::RenderSystem& d_renderSystem;
+
+		//! The GPU program that is our vertex shader
+		Ogre::HighLevelGpuProgramPtr d_vertexShader;
+
+		//! Parameters for vertex shader
+		Ogre::GpuProgramParametersSharedPtr d_vertexParameters;
+
+		//! The GPU program that is our pixel shader
+		Ogre::HighLevelGpuProgramPtr d_pixelShader;
+
+		//! Parameters for pixel shader
+		Ogre::GpuProgramParametersSharedPtr d_pixelParameters;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		Ogre::v1::RenderOperation d_renderOp;
+#endif
+
+		//! The currently active matrix
+		glm::mat4 d_lastMatrix;
+
+		//! The current alpha value
+		float d_previousAlpha;
+
+		//! The physical index to which the matrix will be written
+		size_t d_physicalIndex;
+
+		//! Stores the index where a given type of parameter is bound
+		//! \note Could be using ShaderParamType but the include is avoided by using an int instead
+		std::map<int, size_t> d_paramTypeToIndex;
+	};
+}
+#endif	//CEGUI_OGRE_NEXT
 #endif
 

--- a/cegui/include/CEGUI/RendererModules/Ogre/TextureTarget.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/TextureTarget.h
@@ -27,13 +27,14 @@
 #ifndef _CEGUIOgreTextureTarget_h_
 #define _CEGUIOgreTextureTarget_h_
 
-#include "../../TextureTarget.h"
-#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
-
 #if defined(_MSC_VER)
 #   pragma warning(push)
 #   pragma warning(disable : 4250)
 #endif
+
+#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
+#ifdef CEGUI_OGRE_NEXT
+#include "../../TextureTarget.h"
 
 // Start of CEGUI namespace section
 namespace CEGUI
@@ -66,9 +67,52 @@ protected:
 };
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "../../TextureTarget.h"
+#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
+
+#if defined(_MSC_VER)
+#   pragma warning(push)
+#   pragma warning(disable : 4250)
+#endif
+
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	//! CEGUI::TextureTarget implementation for the Ogre engine.
+	class OGRE_GUIRENDERER_API OgreTextureTarget : public OgreRenderTarget, public TextureTarget
+	{
+	public:
+		//! Constructor.
+		OgreTextureTarget(OgreRenderer& owner, Ogre::RenderSystem& rs, bool addStencilBuffer);
+		//! Destructor.
+		virtual ~OgreTextureTarget();
+
+		// implementation of RenderTarget interface
+		bool isImageryCache() const;
+		// implement CEGUI::TextureTarget interface.
+		void clear();
+		Texture& getTexture() const;
+		void declareRenderSize(const Sizef& sz);
+
+	protected:
+		//! default / initial size for the underlying texture.
+		static const float DEFAULT_SIZE;
+		//! static data used for creating texture names
+		static std::uint32_t s_textureNumber;
+		//! helper to generate unique texture names
+		static String generateTextureName();
+		//! This wraps d_texture so it can be used by the core CEGUI lib.
+		OgreTexture* d_CEGUITexture;
+	};
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)
 #endif
 
 #endif  // end of guard _CEGUIOgreTextureTarget_h_
+
+

--- a/cegui/include/CEGUI/RendererModules/Ogre/WindowTarget.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/WindowTarget.h
@@ -28,6 +28,8 @@
 #define _CEGUIOgreWindowTarget_h_
 
 #include "CEGUI/RendererModules/Ogre/RenderTarget.h"
+#ifdef CEGUI_OGRE_NEXT
+#include <OgreTextureGpu.h>
 
 // Start of CEGUI namespace section
 namespace CEGUI
@@ -37,8 +39,7 @@ class OGRE_GUIRENDERER_API OgreWindowTarget : public OgreRenderTarget
 {
 public:
     //! Constructor
-    OgreWindowTarget(OgreRenderer& owner, Ogre::RenderSystem& rs,
-                     Ogre::RenderTarget& target);
+    OgreWindowTarget(OgreRenderer& owner, Ogre::RenderSystem& rs, Ogre::Window* target);
 
     //! Destructor
     virtual ~OgreWindowTarget();
@@ -52,16 +53,54 @@ public:
         Reference to an Ogre::RenderTarget object that will receive the rendered
         output.
     */
-    void setOgreRenderTarget(Ogre::RenderTarget& target);
+    void setOgreRenderTarget(Ogre::Window* target);
 
     // implement parts of CEGUI::RenderTarget interface
     bool isImageryCache() const;
 
 protected:
     //! helper function to initialise the render target details
-    void initRenderTarget(Ogre::RenderTarget& target);
+    void initRenderTarget(Ogre::Window* target);
 };
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
 
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	//! CEGUI::RenderTarget that targets an existing gre::RenderTarget
+	class OGRE_GUIRENDERER_API OgreWindowTarget : public OgreRenderTarget
+	{
+	public:
+		//! Constructor
+		OgreWindowTarget(OgreRenderer& owner, Ogre::RenderSystem& rs,
+			Ogre::RenderTarget& target);
+
+		//! Destructor
+		virtual ~OgreWindowTarget();
+
+		/*!
+		\brief
+			Set the Ogre::RenderTarget that the output from the OgreWindowTarget
+			should be rendered to.
+
+		\param target
+			Reference to an Ogre::RenderTarget object that will receive the rendered
+			output.
+		*/
+		void setOgreRenderTarget(Ogre::RenderTarget& target);
+
+		// implement parts of CEGUI::RenderTarget interface
+		bool isImageryCache() const;
+
+	protected:
+		//! helper function to initialise the render target details
+		void initRenderTarget(Ogre::RenderTarget& target);
+	};
+
+} // End of  CEGUI namespace section
+
+#endif	//CEGUI_OGRE_NEXT
 #endif  // end of guard _CEGUIOgreWindowTarget_h_

--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -24,8 +24,11 @@
  *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
-#include "CEGUI/RendererModules/Ogre/OgreMacros.h"
 #include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
+
+#ifdef CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/OgreMacros.h"
+#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
 #include "CEGUI/RendererModules/Ogre/Texture.h"
 #include "CEGUI/RendererModules/Ogre/ShaderWrapper.h"
 #include "CEGUI/Vertex.h"
@@ -34,17 +37,14 @@
 #include "CEGUI/ShaderParameterBindings.h"
 
 #include <OgreRenderSystem.h>
-#include <OgreHardwareBufferManager.h>
 #include <OgreQuaternion.h>
 #include <OgreManualObject.h>
 #include <OgreRenderOperation.h>
 #include <OgreSceneManager.h>
-
-#ifdef CEGUI_USE_OGRE_HLMS
+#include <OgreProfiler.h>
 #include <OgreHlmsSamplerblock.h>
-#include <OgreRenderTarget.h>
-#include <OgreViewport.h>
-#endif
+#include <OgreTextureGpu.h>
+#include <OgreHardwareBufferManager.h>
 
 #include "glm/glm.hpp"
 #include "glm/gtc/quaternion.hpp"
@@ -65,9 +65,10 @@ OgreGeometryBuffer::OgreGeometryBuffer(OgreRenderer& owner,
     d_matrix(1.0),
     d_expectedData(MT_INVALID),
     d_dataAppended(false),
-    d_previousAlphaValue(-1.f)
+    d_previousAlphaValue(-1.f),
+	d_currentRenderTarget(0),
+	d_isFirstDrawOfFrame(true)
 {
-
 }
 
 //----------------------------------------------------------------------------//
@@ -79,55 +80,44 @@ OgreGeometryBuffer::~OgreGeometryBuffer()
 //----------------------------------------------------------------------------//
 void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
 {
-    CEGUI_UNUSED(drawModeMask);
+	//OgreProfile("CEGUI OgreGeometryBuffer draw");
+
+	CEGUI_UNUSED(drawModeMask);
 
     if (d_vertexData.empty())
         return;
 
-    if (d_dataAppended)
-        syncVertexData();
+	if(d_dataAppended)
+	{
+		//OgreProfile("CEGUI OgreGeometryBuffer draw syncVertexData");
+		syncVertexData();
+	}
 
     if (OGRE_ISNULL(d_hwBuffer))
         return;
 
-#ifdef CEGUI_USE_OGRE_HLMS
-    //Ogre::Viewport* previousViewport = d_renderSystem._getViewport();
-    //Ogre::Viewport* currentViewport = d_owner.getOgreRenderTarget()->getViewport(0);
-    
-    // If this viewport approach fails we'll probably need to mess with the
-    // set hlms macro block in the Renderer
-    Ogre::Viewport* currentViewport = d_renderSystem._getViewport();
+	//if(!getCurrentOgreRenderTarget())
+	//	return;
 
-    Rectf previousClipRect;
-    previousClipRect.left(currentViewport->getScissorLeft());
-    previousClipRect.top(currentViewport->getScissorTop());
-    previousClipRect.right(currentViewport->getScissorWidth());
-    previousClipRect.bottom(currentViewport->getScissorHeight());
-#endif //CEGUI_USE_OGRE_HLMS
-    
-    // setup clip region
-    if (d_clippingActive)
-    {
-    #ifdef CEGUI_USE_OGRE_HLMS
-        setScissorRects(currentViewport);
-		
-		// clear and re-set viewport to have ogre apply the actual scissor settings
-		d_renderSystem._setViewport(NULL);
-		d_renderSystem._setViewport(currentViewport);
-    #else
-        setScissorRects();
-    #endif //CEGUI_USE_OGRE_HLMS
-    }
+	Ogre::Vector4 viewPortSize = getCurrentOgreRenderTarget()->getViewportSize();
+	Ogre::Vector4 scissors = getScissors();
+	Ogre::RenderPassDescriptor* renderPassDescriptor = d_isFirstDrawOfFrame ? getCurrentOgreRenderTarget()->getRenderPassDescriptorForFirstDraw() : getCurrentOgreRenderTarget()->getRenderPassDescriptorForAddionalDraw();
+
+	d_renderSystem.beginRenderPassDescriptor(renderPassDescriptor, getCurrentOgreRenderTarget()->getTextureGpuTarget(), 0,
+		&viewPortSize, &scissors, 1, false, false);
+	d_renderSystem.executeRenderPassDescriptorDelayedActions();
 
     // Update the matrix
+	//OgreProfileBegin("CEGUI OgreGeometryBuffer draw updateMatrix");
     updateMatrix();
+	//OgreProfileEnd("CEGUI OgreGeometryBuffer draw updateMatrix");
 
+	//OgreProfileBegin("CEGUI OgreGeometryBuffer draw shader");
     CEGUI::ShaderParameterBindings* shaderParameterBindings = 
         (*d_renderMaterial).getShaderParamBindings();
 
     // Set the ModelViewProjection matrix in the bindings
     shaderParameterBindings->setParameter("modelViewProjMatrix", d_matrix);
-
 
     if (d_alpha != d_previousAlphaValue)
     {
@@ -142,11 +132,14 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
 
     // get the impl specific shader wrapper so we can set the necessary render ops in the draw passes.
     OgreShaderWrapper *shaderWrapper = static_cast<OgreShaderWrapper*>( const_cast<ShaderWrapper*>( d_renderMaterial->getShaderWrapper() ) );
+	//OgreProfileEnd("CEGUI OgreGeometryBuffer draw shader");
 
     const int pass_count = d_effect ? d_effect->getPassCount() : 1;
     for (int pass = 0; pass < pass_count; ++pass)
     {
-        // set up RenderEffect
+		//OgreProfile("CEGUI OgreGeometryBuffer draw passloop");
+
+		// set up RenderEffect
         if (d_effect)
             d_effect->performPreRenderFunctions(pass);
 
@@ -156,10 +149,7 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
         // which contains all the blend settings etc
         // This is required because the material cannot set shader parameters before
         // the PSO is bound
-
-    #ifdef CEGUI_USE_OGRE_HLMS
         shaderWrapper->setRenderOperation( d_renderOp );
-    #endif //CEGUI_USE_OGRE_HLMS
         d_renderMaterial->prepareForRendering();
 
         // draw the geometry
@@ -170,23 +160,14 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
     if (d_effect)
         d_effect->performPostRenderFunctions();
 
-    // Disable clipping after rendering
-    if (d_clippingActive)
-    {
-    #ifdef CEGUI_USE_OGRE_HLMS
-        currentViewport->setScissors(previousClipRect.left(), previousClipRect.top(),
-            previousClipRect.right(), previousClipRect.bottom());
-        // Restore viewport? d_renderSystem._setViewport(previousViewport);
-		
-		// clear and re-set viewport to have ogre apply the previous scissor settings
-		d_renderSystem._setViewport(NULL);
-		d_renderSystem._setViewport(currentViewport);
-    #else
-        d_renderSystem.setScissorTest(false);
-    #endif //CEGUI_USE_OGRE_HLMS
-    }
-
+	//OgreProfileBegin("CEGUI OgreGeometryBuffer draw updateRenderTargetData");
     updateRenderTargetData(d_owner.getActiveRenderTarget());
+	//OgreProfileEnd("CEGUI OgreGeometryBuffer draw updateRenderTargetData");
+}
+
+void OgreGeometryBuffer::setCurrentRenderTarget(OgreRenderTarget* renderTarget)
+{
+	d_currentRenderTarget = renderTarget;
 }
 
 //----------------------------------------------------------------------------//
@@ -225,13 +206,8 @@ void OgreGeometryBuffer::syncVertexData() const
 
             setVertexBuffer(d_vertexCount);
         }
-    #ifdef CEGUI_USE_OGRE_HLMS
         void* copy_target = d_hwBuffer->lock(
             Ogre::v1::HardwareVertexBuffer::HBL_DISCARD);
-    #else
-        void* copy_target = d_hwBuffer->lock(
-            Ogre::HardwareVertexBuffer::HBL_DISCARD); 
-    #endif //CEGUI_USE_OGRE_HLMS
 
         assert(copy_target && "Ogre vertex buffer is invalid");
 
@@ -246,6 +222,17 @@ void OgreGeometryBuffer::syncVertexData() const
     d_renderOp.vertexData->vertexCount = d_vertexCount;
 
     d_dataAppended = false;
+}
+
+OgreRenderTarget* OgreGeometryBuffer::getCurrentOgreRenderTarget() const
+{
+#if 0
+	CEGUI::RenderTarget* target = d_owner.getActiveRenderTarget();
+	OgreRenderTarget* ogreTarget = static_cast<OgreRenderTarget*>(target);
+	return ogreTarget;
+#else
+	return d_currentRenderTarget;
+#endif
 }
 
 //----------------------------------------------------------------------------//
@@ -271,24 +258,16 @@ void OgreGeometryBuffer::finaliseVertexAttributes(MANUALOBJECT_TYPE type)
 {
     d_expectedData = type;
     
-#ifdef CEGUI_USE_OGRE_HLMS
     // basic initialisation of render op
-    d_renderOp.vertexData = OGRE_NEW Ogre::v1::VertexData();
+	Ogre::v1::HardwareBufferManagerBase* hardwareBufferManager = Ogre::v1::HardwareBufferManager::getSingletonPtr();
+
+    d_renderOp.vertexData = OGRE_NEW Ogre::v1::VertexData(hardwareBufferManager);
     d_renderOp.operationType = Ogre::OT_TRIANGLE_LIST;
     d_renderOp.useIndexes = false;
 
     // Setup our render operation to match the type
     Ogre::v1::VertexDeclaration* vd = d_renderOp.vertexData->vertexDeclaration;
-#else
-    // basic initialisation of render op
-    d_renderOp.vertexData = OGRE_NEW Ogre::VertexData();
-    d_renderOp.operationType = Ogre::RenderOperation::OT_TRIANGLE_LIST;
-    d_renderOp.useIndexes = false;
-
-    // Setup our render operation to match the type
-    Ogre::VertexDeclaration* vd = d_renderOp.vertexData->vertexDeclaration;
-#endif //CEGUI_USE_OGRE_HLMS
-
+	
     switch(d_expectedData)
     {
     case MT_COLOURED: 
@@ -314,7 +293,6 @@ void OgreGeometryBuffer::finaliseVertexAttributes(MANUALOBJECT_TYPE type)
         throw RendererException(
             "Unknown d_expectedData type.");
     }
-
 }
 
 void OgreGeometryBuffer::setVertexBuffer(size_t count) const
@@ -332,17 +310,10 @@ void OgreGeometryBuffer::setVertexBuffer(size_t count) const
     } else {
 
         // Create a new vertex buffer
-    #ifdef CEGUI_USE_OGRE_HLMS
         d_hwBuffer = Ogre::v1::HardwareBufferManager::getSingleton().
             createVertexBuffer(getVertexAttributeElementCount()*sizeof(float), count,
                 Ogre::v1::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE,
                 false);
-    #else
-        d_hwBuffer = Ogre::HardwareBufferManager::getSingleton().
-            createVertexBuffer(getVertexAttributeElementCount()*sizeof(float), count,
-                Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE,
-                false);
-    #endif //CEGUI_USE_OGRE_HLMS
     }
 
     if (OGRE_ISNULL(d_hwBuffer))
@@ -369,32 +340,23 @@ void OgreGeometryBuffer::cleanUpVertexAttributes()
 }
 
 // ------------------------------------ //
-#ifdef CEGUI_USE_OGRE_HLMS
-void OgreGeometryBuffer::setScissorRects(Ogre::Viewport* current_viewport) const
+Ogre::Vector4 OgreGeometryBuffer::getScissors() const
 {
-    int actualWidth = current_viewport->getActualWidth();
-    int actualHeight = current_viewport->getActualHeight();
-    float scissorsLeft = d_preparedClippingRegion.left() / actualWidth;
-    float scissorsTop = d_preparedClippingRegion.top() / actualHeight;
-    float scissorsWidth = (d_preparedClippingRegion.right() -
-        d_preparedClippingRegion.left()) / actualWidth;
-    float scissorsHeight = (d_preparedClippingRegion.bottom() -
-        d_preparedClippingRegion.top()) / actualHeight;
-    
-    current_viewport->setScissors(scissorsLeft, scissorsTop, scissorsWidth,
-        scissorsHeight);
-}
+	Ogre::TextureGpu* target = getCurrentOgreRenderTarget()->getTextureGpuTarget();
 
-#else
-void OgreGeometryBuffer::setScissorRects() const
-{
-    d_renderSystem.setScissorTest(true,
-        static_cast<size_t>(d_preparedClippingRegion.left()), 
-        static_cast<size_t>(d_preparedClippingRegion.top()),
-        static_cast<size_t>(d_preparedClippingRegion.right()),
-        static_cast<size_t>(d_preparedClippingRegion.bottom()));
+	int actualWidth = target->getWidth();
+	int actualHeight = target->getHeight();
+	float scissorsLeft = d_preparedClippingRegion.left() / actualWidth;
+	float scissorsTop = d_preparedClippingRegion.top() / actualHeight;
+	float scissorsWidth = (d_preparedClippingRegion.right() -
+		d_preparedClippingRegion.left()) / actualWidth;
+	float scissorsHeight = (d_preparedClippingRegion.bottom() -
+		d_preparedClippingRegion.top()) / actualHeight;
+
+	Ogre::Vector4 scissors(scissorsLeft, scissorsTop, scissorsWidth, scissorsHeight);
+
+	return scissors;
 }
-#endif //CEGUI_USE_OGRE_HLMS
 
 // ------------------------------------ //
 void OgreGeometryBuffer::reset()
@@ -421,3 +383,419 @@ int OgreGeometryBuffer::getVertexAttributeElementCount() const
 }
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/OgreMacros.h"
+#include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/RendererModules/Ogre/ShaderWrapper.h"
+#include "CEGUI/Vertex.h"
+#include "CEGUI/RenderEffect.h"
+#include "CEGUI/Exceptions.h"
+#include "CEGUI/ShaderParameterBindings.h"
+
+#include <OgreRenderSystem.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreQuaternion.h>
+#include <OgreManualObject.h>
+#include <OgreRenderOperation.h>
+#include <OgreSceneManager.h>
+#include <OgreProfiler.h>
+
+#ifdef CEGUI_USE_OGRE_HLMS
+#include <OgreHlmsSamplerblock.h>
+#include <OgreRenderTarget.h>
+#include <OgreViewport.h>
+#endif
+
+#include "glm/glm.hpp"
+#include "glm/gtc/quaternion.hpp"
+#include "glm/gtc/type_ptr.hpp"
+
+#define FLOATS_PER_TEXTURED     9
+#define FLOATS_PER_COLOURED     7
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+
+	OgreGeometryBuffer::OgreGeometryBuffer(OgreRenderer& owner,
+		Ogre::RenderSystem& rs, CEGUI::RefCounted<RenderMaterial> renderMaterial) :
+		GeometryBuffer(renderMaterial),
+		d_owner(owner),
+		d_renderSystem(rs),
+		d_matrix(1.0),
+		d_expectedData(MT_INVALID),
+		d_dataAppended(false),
+		d_previousAlphaValue(-1.f)
+	{
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreGeometryBuffer::~OgreGeometryBuffer()
+	{
+		cleanUpVertexAttributes();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
+	{
+		//OgreProfile("CEGUI OgreGeometryBuffer draw");
+
+		CEGUI_UNUSED(drawModeMask);
+
+		if(d_vertexData.empty())
+			return;
+
+		if(d_dataAppended)
+		{
+			//OgreProfile("CEGUI OgreGeometryBuffer draw syncVertexData");
+			syncVertexData();
+		}
+
+		if(OGRE_ISNULL(d_hwBuffer))
+			return;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		//Ogre::Viewport* previousViewport = d_renderSystem._getViewport();
+		//Ogre::Viewport* currentViewport = d_owner.getOgreRenderTarget()->getViewport(0);
+
+		// If this viewport approach fails we'll probably need to mess with the
+		// set hlms macro block in the Renderer
+		Ogre::Viewport* currentViewport = d_renderSystem._getViewport();
+
+		Rectf previousClipRect;
+		previousClipRect.left(currentViewport->getScissorLeft());
+		previousClipRect.top(currentViewport->getScissorTop());
+		previousClipRect.right(currentViewport->getScissorWidth());
+		previousClipRect.bottom(currentViewport->getScissorHeight());
+#endif //CEGUI_USE_OGRE_HLMS
+
+		// setup clip region
+		if(d_clippingActive)
+		{
+#ifdef CEGUI_USE_OGRE_HLMS
+			//OgreProfile("CEGUI OgreGeometryBuffer draw clipping");
+			setScissorRects(currentViewport);
+
+			// if needed clear and re-set viewport to have ogre apply the acual scissor settings
+			// clear and re-set viewport to have ogre apply the actual scissor settings
+			d_renderSystem._setViewport(NULL);
+			d_renderSystem._setViewport(currentViewport);
+#else
+			setScissorRects();
+#endif //CEGUI_USE_OGRE_HLMS
+		}
+
+		// Update the matrix
+		//OgreProfileBegin("CEGUI OgreGeometryBuffer draw updateMatrix");
+		updateMatrix();
+		//OgreProfileEnd("CEGUI OgreGeometryBuffer draw updateMatrix");
+
+		//OgreProfileBegin("CEGUI OgreGeometryBuffer draw shader");
+		CEGUI::ShaderParameterBindings* shaderParameterBindings =
+			(*d_renderMaterial).getShaderParamBindings();
+
+		// Set the ModelViewProjection matrix in the bindings
+		shaderParameterBindings->setParameter("modelViewProjMatrix", d_matrix);
+
+
+		if(d_alpha != d_previousAlphaValue)
+		{
+			d_previousAlphaValue = d_alpha;
+
+			shaderParameterBindings->setParameter("alphaPercentage",
+				d_previousAlphaValue);
+		}
+
+		// activate the desired blending mode
+		d_owner.bindBlendMode(d_blendMode);
+
+		// get the impl specific shader wrapper so we can set the necessary render ops in the draw passes.
+		OgreShaderWrapper *shaderWrapper = static_cast<OgreShaderWrapper*>(const_cast<ShaderWrapper*>(d_renderMaterial->getShaderWrapper()));
+		//OgreProfileEnd("CEGUI OgreGeometryBuffer draw shader");
+
+		const int pass_count = d_effect ? d_effect->getPassCount() : 1;
+		for(int pass = 0; pass < pass_count; ++pass)
+		{
+			//OgreProfile("CEGUI OgreGeometryBuffer draw passloop");
+
+			// set up RenderEffect
+			if(d_effect)
+				d_effect->performPreRenderFunctions(pass);
+
+			//Prepare for the rendering process according to the used render material
+
+			// Starting with Ogre 2.1 this also activates the PSO
+			// which contains all the blend settings etc
+			// This is required because the material cannot set shader parameters before
+			// the PSO is bound
+
+#ifdef CEGUI_USE_OGRE_HLMS
+			shaderWrapper->setRenderOperation(d_renderOp);
+#endif //CEGUI_USE_OGRE_HLMS
+			d_renderMaterial->prepareForRendering();
+
+			// draw the geometry
+			d_renderSystem._render(d_renderOp);
+		}
+
+		// clean up RenderEffect
+		if(d_effect)
+			d_effect->performPostRenderFunctions();
+
+		// Disable clipping after rendering
+		if(d_clippingActive)
+		{
+#ifdef CEGUI_USE_OGRE_HLMS
+			//OgreProfile("CEGUI OgreGeometryBuffer draw clipping");
+			currentViewport->setScissors(previousClipRect.left(), previousClipRect.top(),
+				previousClipRect.right(), previousClipRect.bottom());
+			// Restore viewport? d_renderSystem._setViewport(previousViewport);
+
+			// clear and re-set viewport to have ogre apply the previous scissor settings
+			d_renderSystem._setViewport(NULL);
+			d_renderSystem._setViewport(currentViewport);
+#else
+			d_renderSystem.setScissorTest(false);
+#endif //CEGUI_USE_OGRE_HLMS
+		}
+
+		//OgreProfileBegin("CEGUI OgreGeometryBuffer draw updateRenderTargetData");
+		updateRenderTargetData(d_owner.getActiveRenderTarget());
+		//OgreProfileEnd("CEGUI OgreGeometryBuffer draw updateRenderTargetData");
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGeometryBuffer::appendGeometry(const float* vertex_data, std::size_t array_size)
+	{
+		GeometryBuffer::appendGeometry(vertex_data, array_size);
+
+		d_dataAppended = true;
+	}
+
+	void OgreGeometryBuffer::syncVertexData() const
+	{
+		if(!d_dataAppended)
+			return;
+
+		// Make sure that our vertex buffer is large enough
+		size_t current_size;
+
+		if(!OGRE_ISNULL(d_hwBuffer) &&
+			(current_size = d_hwBuffer->getNumVertices()) < d_vertexCount)
+		{
+			size_t new_size = current_size;
+
+			// Reallocate the buffer to be large enough
+			while(new_size < d_vertexCount)
+				new_size *= 2;
+
+			setVertexBuffer(new_size);
+		}
+
+		// copy vertex data into the Ogre hardware buffer
+		if(d_vertexCount > 0)
+		{
+			if(OGRE_ISNULL(d_hwBuffer))
+			{
+
+				setVertexBuffer(d_vertexCount);
+			}
+#ifdef CEGUI_USE_OGRE_HLMS
+			void* copy_target = d_hwBuffer->lock(
+				Ogre::v1::HardwareVertexBuffer::HBL_DISCARD);
+#else
+			void* copy_target = d_hwBuffer->lock(
+				Ogre::HardwareVertexBuffer::HBL_DISCARD);
+#endif //CEGUI_USE_OGRE_HLMS
+
+			assert(copy_target && "Ogre vertex buffer is invalid");
+
+			std::memcpy(copy_target, &d_vertexData[0], d_vertexData.size() *
+				sizeof(float));
+
+			d_hwBuffer->unlock();
+		}
+
+		// Update rendering for the new vertices
+		d_renderOp.vertexData->vertexStart = 0;
+		d_renderOp.vertexData->vertexCount = d_vertexCount;
+
+		d_dataAppended = false;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGeometryBuffer::updateMatrix() const
+	{
+		d_matrixValid = false;
+		if(!d_matrixValid || !isRenderTargetDataValid(d_owner.getActiveRenderTarget()))
+		{
+			// Apply the view projection matrix to the model matrix and save the result as cached matrix
+			d_matrix = d_owner.getViewProjectionMatrix() * getModelMatrix();
+
+			//If necessary: transpose
+			const OgreShaderWrapper* ogreShader = static_cast<const OgreShaderWrapper*>(d_renderMaterial->getShaderWrapper());
+			if(!ogreShader->getVertexParameters()->getTransposeMatrices())
+				d_matrix = glm::transpose(d_matrix);
+
+			d_matrixValid = true;
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGeometryBuffer::finaliseVertexAttributes(MANUALOBJECT_TYPE type)
+	{
+		d_expectedData = type;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		// basic initialisation of render op
+		d_renderOp.vertexData = OGRE_NEW Ogre::v1::VertexData();
+		d_renderOp.operationType = Ogre::OT_TRIANGLE_LIST;
+		d_renderOp.useIndexes = false;
+
+		// Setup our render operation to match the type
+		Ogre::v1::VertexDeclaration* vd = d_renderOp.vertexData->vertexDeclaration;
+#else
+		// basic initialisation of render op
+		d_renderOp.vertexData = OGRE_NEW Ogre::VertexData();
+		d_renderOp.operationType = Ogre::RenderOperation::OT_TRIANGLE_LIST;
+		d_renderOp.useIndexes = false;
+
+		// Setup our render operation to match the type
+		Ogre::VertexDeclaration* vd = d_renderOp.vertexData->vertexDeclaration;
+#endif //CEGUI_USE_OGRE_HLMS
+
+		switch(d_expectedData)
+		{
+		case MT_COLOURED:
+		{
+			vd->addElement(0, 0, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+
+			vd->addElement(0, sizeof(float) * 3, Ogre::VET_COLOUR,
+				Ogre::VES_DIFFUSE);
+			break;
+		}
+		case MT_TEXTURED:
+		{
+			vd->addElement(0, 0, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+
+			vd->addElement(0, sizeof(float) * 3, Ogre::VET_FLOAT4,
+				Ogre::VES_DIFFUSE);
+
+			vd->addElement(0, sizeof(float)*(3 + 4), Ogre::VET_FLOAT2,
+				Ogre::VES_TEXTURE_COORDINATES);
+			break;
+		}
+		default:
+			throw RendererException(
+				"Unknown d_expectedData type.");
+		}
+
+	}
+
+	void OgreGeometryBuffer::setVertexBuffer(size_t count) const
+	{
+		// We first check if some other buffer has already allocated a suited buffer
+		// for us
+		// We use auto here because the return type depends on Ogre version
+		auto already_created = d_owner.getVertexBuffer(count);
+
+		if(!OGRE_ISNULL(already_created))
+		{
+
+			d_hwBuffer = already_created;
+
+		}
+		else {
+
+			// Create a new vertex buffer
+#ifdef CEGUI_USE_OGRE_HLMS
+			d_hwBuffer = Ogre::v1::HardwareBufferManager::getSingleton().
+				createVertexBuffer(getVertexAttributeElementCount() * sizeof(float), count,
+					Ogre::v1::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE,
+					false);
+#else
+			d_hwBuffer = Ogre::HardwareBufferManager::getSingleton().
+				createVertexBuffer(getVertexAttributeElementCount() * sizeof(float), count,
+					Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE,
+					false);
+#endif //CEGUI_USE_OGRE_HLMS
+		}
+
+		if(OGRE_ISNULL(d_hwBuffer))
+		{
+			throw RendererException("Failed to create Ogre vertex buffer, "
+				"probably because the vertex layout is invalid.");
+		}
+
+		// bind the vertex buffer for rendering
+		d_renderOp.vertexData->vertexBufferBinding->setBinding(0, d_hwBuffer);
+	}
+
+	void OgreGeometryBuffer::cleanUpVertexAttributes()
+	{
+		OGRE_DELETE d_renderOp.vertexData;
+		d_renderOp.vertexData = 0;
+
+		// Store the hardware buffer so that other instances can use it later
+		// This check should also help prevent there being nullptrs in the pool
+		if(d_hwBuffer.get())
+			d_owner.returnVertexBuffer(d_hwBuffer);
+
+		OGRE_RESET(d_hwBuffer);
+	}
+
+	// ------------------------------------ //
+#ifdef CEGUI_USE_OGRE_HLMS
+	void OgreGeometryBuffer::setScissorRects(Ogre::Viewport* current_viewport) const
+	{
+		int actualWidth = current_viewport->getActualWidth();
+		int actualHeight = current_viewport->getActualHeight();
+		float scissorsLeft = d_preparedClippingRegion.left() / actualWidth;
+		float scissorsTop = d_preparedClippingRegion.top() / actualHeight;
+		float scissorsWidth = (d_preparedClippingRegion.right() -
+			d_preparedClippingRegion.left()) / actualWidth;
+		float scissorsHeight = (d_preparedClippingRegion.bottom() -
+			d_preparedClippingRegion.top()) / actualHeight;
+
+		current_viewport->setScissors(scissorsLeft, scissorsTop, scissorsWidth,
+			scissorsHeight);
+	}
+
+#else
+	void OgreGeometryBuffer::setScissorRects() const
+	{
+		d_renderSystem.setScissorTest(true,
+			static_cast<size_t>(d_preparedClippingRegion.left()),
+			static_cast<size_t>(d_preparedClippingRegion.top()),
+			static_cast<size_t>(d_preparedClippingRegion.right()),
+			static_cast<size_t>(d_preparedClippingRegion.bottom()));
+	}
+#endif //CEGUI_USE_OGRE_HLMS
+
+	// ------------------------------------ //
+	void OgreGeometryBuffer::reset()
+	{
+		d_vertexData.clear();
+		d_clippingActive = true;
+	}
+
+	// ------------------------------------ //
+	int OgreGeometryBuffer::getVertexAttributeElementCount() const
+	{
+		switch(d_expectedData)
+		{
+		case MT_COLOURED:
+			return FLOATS_PER_COLOURED;
+			break;
+		case MT_TEXTURED:
+			return FLOATS_PER_TEXTURED;
+			break;
+		default:
+			return 0;
+			break;
+		}
+	}
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/ImageCodec.cpp
+++ b/cegui/src/RendererModules/Ogre/ImageCodec.cpp
@@ -25,9 +25,14 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/ImageCodec.h"
+
+#ifdef CEGUI_OGRE_NEXT
 #include "CEGUI/RendererModules/Ogre/Texture.h"
 #include "CEGUI/Exceptions.h"
 #include <Ogre.h>
+#include <OgreImage2.h>
+#include <OgreTextureBox.h>
+#include <OgreTextureGpuManager.h>
 
 // Start of CEGUI namespace section
 namespace CEGUI
@@ -53,32 +58,32 @@ const String& OgreImageCodec::getImageFileDataType() const
 //----------------------------------------------------------------------------//
 Texture* OgreImageCodec::load(const RawDataContainer& data, Texture* result)
 {
-    using namespace Ogre;
-
-    // wrap the buffer of the RawDataContainer with an Ogre::MemoryDataStream.
-    DataStreamPtr stream(
-        OGRE_NEW MemoryDataStream(
+	// wrap the buffer of the RawDataContainer with an Ogre::MemoryDataStream.
+    Ogre::DataStreamPtr stream(
+        OGRE_NEW Ogre::MemoryDataStream(
             const_cast<void*>(static_cast<const void*>(data.getDataPtr())),
             data.getSize(), false));
 
     // load the image
-    Ogre::Image image;
+    Ogre::Image2 image;
 #if (CEGUI_STRING_CLASS != CEGUI_STRING_CLASS_UTF_32) 
     image.load(stream, d_dataTypeID.c_str());
 #else
     image.load(stream, String::convertUtf32ToUtf8(d_dataTypeID.getString()).c_str());
 #endif
 
-    const PixelFormat ogre_pf = image.getFormat();
-    const Texture::PixelFormat cegui_pf =
-        OgreTexture::fromOgrePixelFormat(ogre_pf);
 
+    const Ogre::PixelFormatGpu ogre_pf = image.getPixelFormat();
+    const Texture::PixelFormat cegui_pf = OgreTexture::fromOgrePixelFormat(ogre_pf);
+
+#if 0	//no pixelformats which are needed to be corrected, therefore this section is disabled for now
     // discover the pixel format and number of pixel components
     int components;
-    bool rbswap;
+	bool rbswap = false;
+	bool rbswapForRGBA = false;
     switch (ogre_pf)
     {
-        case PF_R8G8B8:
+        /*case PF_R8G8B8:
             rbswap = true;
             components = 3;
             break;
@@ -86,17 +91,28 @@ Texture* OgreImageCodec::load(const RawDataContainer& data, Texture* result)
         case PF_A8R8G8B8:
             rbswap = true;
             components = 4;
-            break;
+            break;*/
 
+#if 0 //does seam to be no more needed
+		case PFG_RGBA8_UNORM:
+			rbswapForRGBA = true;
+			components = 4;
+			break;
+
+		case PFG_RGBA8_UNORM_SRGB:
+			rbswapForRGBA = true;
+			components = 4;
+			break;
+#endif
         default:
             rbswap = false;
             break;
     }
 
-    // do the old switcharoo on R and B if needed
+	// do the old switcharoo on R and B if needed
     if (rbswap)
     {
-        std::uint8_t* dat = image.getData();
+        std::uint8_t* dat = reinterpret_cast<Ogre::uint8*>(image.getData(0u).data);
         for (unsigned int j = 0; j < image.getHeight(); ++j)
         {
             for (unsigned int i = 0; i < image.getWidth(); ++i)
@@ -105,20 +121,120 @@ Texture* OgreImageCodec::load(const RawDataContainer& data, Texture* result)
                 dat[i * components + 0] = dat[i * components + 2];
                 dat[i * components + 2] = tmp;
             }
-
-            dat += image.getRowSpan();
+			dat += image.getBytesPerRow(0u);
         }
     }
+#endif
+	// load the resulting image into the texture
+	Ogre::TextureBox textureBox = image.getData(0u);
+	const void* imageData = image.getData(0u).data;
 
-    // load the resulting image into the texture
-    result->loadFromMemory(image.getData(),
-                           Sizef(static_cast<float>(image.getWidth()),
-                                 static_cast<float>(image.getHeight()) ),
-                           cegui_pf);
+	result->loadFromMemory(imageData, Sizef(static_cast<float>(image.getWidth()), static_cast<float>(image.getHeight())), cegui_pf);
+	return result;
 
-    return result;
 }
 
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
+
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/ImageCodec.h"
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/Exceptions.h"
+#include <Ogre.h>
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+	//----------------------------------------------------------------------------//
+	OgreImageCodec::OgreImageCodec() :
+		ImageCodec("OgreImageCodec - Integrated ImageCodec using the Ogre engine.")
+	{
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreImageCodec::setImageFileDataType(const String& type)
+	{
+		d_dataTypeID = type;
+	}
+
+	//----------------------------------------------------------------------------//
+	const String& OgreImageCodec::getImageFileDataType() const
+	{
+		return d_dataTypeID;
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture* OgreImageCodec::load(const RawDataContainer& data, Texture* result)
+	{
+		using namespace Ogre;
+
+		// wrap the buffer of the RawDataContainer with an Ogre::MemoryDataStream.
+		DataStreamPtr stream(
+			OGRE_NEW MemoryDataStream(
+				const_cast<void*>(static_cast<const void*>(data.getDataPtr())),
+				data.getSize(), false));
+
+		// load the image
+		Ogre::Image image;
+#if (CEGUI_STRING_CLASS != CEGUI_STRING_CLASS_UTF_32) 
+		image.load(stream, d_dataTypeID.c_str());
+#else
+		image.load(stream, String::convertUtf32ToUtf8(d_dataTypeID.getString()).c_str());
+#endif
+
+		const PixelFormat ogre_pf = image.getFormat();
+		const Texture::PixelFormat cegui_pf =
+			OgreTexture::fromOgrePixelFormat(ogre_pf);
+
+		// discover the pixel format and number of pixel components
+		int components;
+		bool rbswap;
+		switch(ogre_pf)
+		{
+		case PF_R8G8B8:
+			rbswap = true;
+			components = 3;
+			break;
+
+		case PF_A8R8G8B8:
+			rbswap = true;
+			components = 4;
+			break;
+
+		default:
+			rbswap = false;
+			break;
+		}
+
+		// do the old switcharoo on R and B if needed
+		if(rbswap)
+		{
+			std::uint8_t* dat = image.getData();
+			for(unsigned int j = 0; j < image.getHeight(); ++j)
+			{
+				for(unsigned int i = 0; i < image.getWidth(); ++i)
+				{
+					std::uint8_t tmp = dat[i * components + 0];
+					dat[i * components + 0] = dat[i * components + 2];
+					dat[i * components + 2] = tmp;
+				}
+
+				dat += image.getRowSpan();
+			}
+		}
+
+		// load the resulting image into the texture
+		result->loadFromMemory(image.getData(),
+			Sizef(static_cast<float>(image.getWidth()),
+				static_cast<float>(image.getHeight())),
+			cegui_pf);
+
+		return result;
+	}
+
+	//----------------------------------------------------------------------------//
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/RenderTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget.cpp
@@ -25,12 +25,13 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/RenderTarget.h"
+#ifdef CEGUI_OGRE_NEXT
 #include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
 #include "CEGUI/Exceptions.h"
 #include "CEGUI/RenderQueue.h"
 
 #include <OgreRenderSystem.h>
-#include <OgreRenderTarget.h>
+#include <OgreTextureGpu.h>
 #include <OgreCamera.h>
 #include <OgreViewport.h>
 
@@ -41,80 +42,142 @@
 // Start of CEGUI namespace section
 namespace CEGUI
 {
-
-
-OgreRenderTarget::OgreRenderTarget(OgreRenderer& owner,
-                                      Ogre::RenderSystem& rs) :
+	
+OgreRenderTarget::OgreRenderTarget(OgreRenderer& owner, Ogre::RenderSystem& rs, bool clearTextureBeforeRendering) :
     d_owner(owner),
     d_renderSystem(rs),
-    d_renderTarget(0),
-    d_viewport(0),
-    d_ogreViewportDimensions(0, 0, 0, 0),
-    d_viewportValid(false)
+	d_textureGpuTarget(0),
+	d_renderPassDescForFirstDraw(0),
+	d_renderPassDescForAddionalDraw(0),
+	d_clearTextureBeforeRendering(clearTextureBeforeRendering),
+	d_viewportSize(0, 0, 1, 1)
 {
 }
 
-
 OgreRenderTarget::~OgreRenderTarget()
 {
-    delete d_viewport;
+	if(d_renderPassDescForFirstDraw)
+		d_renderSystem.destroyRenderPassDescriptor(d_renderPassDescForFirstDraw);
+		
+	if(d_renderPassDescForAddionalDraw)
+		d_renderSystem.destroyRenderPassDescriptor(d_renderPassDescForAddionalDraw);
+}
+
+void OgreRenderTarget::updateRenderPassDescriptor()
+{
+	Ogre::TextureGpu* textureTarget = d_textureGpuTarget;
+
+	if(!textureTarget)
+	{
+		throw std::runtime_error("Error no texture ready (OgreRenderTarget::updateRenderPassDescriptor)");
+	}
+
+	if(!d_renderPassDescForFirstDraw)
+	{
+		d_renderPassDescForFirstDraw = d_renderSystem.createRenderPassDescriptor();
+		d_renderPassDescForFirstDraw->mColour[0].texture = textureTarget;
+		
+		if(d_clearTextureBeforeRendering)
+			d_renderPassDescForFirstDraw->mColour[0].loadAction = Ogre::LoadAction::Clear;
+		else
+			d_renderPassDescForFirstDraw->mColour[0].loadAction = Ogre::LoadAction::DontCare;
+		
+		d_renderPassDescForFirstDraw->mColour[0].clearColour = Ogre::ColourValue(0.0f, 0.0f, 0.0f, 0.0f);
+		d_renderPassDescForFirstDraw->mColour[0].storeAction = Ogre::StoreAction::StoreOrResolve;
+		//Note that resolveTexture should be nullptr if texture isn't msaa.
+		//Also if texture->hasMsaaExplicitResolves() == false, then resolveTexture = texture
+		//is allowed, as the texture will have an internal texture to be used for resolving
+		d_renderPassDescForFirstDraw->mColour[0].resolveTexture = 0;
+		d_renderPassDescForFirstDraw->mDepth.texture = d_renderSystem.getDepthBufferFor(textureTarget, textureTarget->getDepthBufferPoolId(), textureTarget->getPreferDepthTexture(), textureTarget->getDesiredDepthBufferFormat());
+		d_renderPassDescForFirstDraw->mDepth.loadAction = Ogre::LoadAction::Clear;
+		d_renderPassDescForFirstDraw->mDepth.storeAction = Ogre::StoreAction::DontCare;
+		d_renderPassDescForFirstDraw->mStencil.texture = nullptr;
+		d_renderPassDescForFirstDraw->mStencil.loadAction = Ogre::LoadAction::Clear;
+		d_renderPassDescForFirstDraw->mStencil.storeAction = Ogre::StoreAction::DontCare;
+		d_renderPassDescForFirstDraw->entriesModified(Ogre::RenderPassDescriptor::All);
+	}
+
+	if(!d_renderPassDescForAddionalDraw)
+	{
+		d_renderPassDescForAddionalDraw = d_renderSystem.createRenderPassDescriptor();
+		d_renderPassDescForAddionalDraw->mColour[0].texture = textureTarget;
+		d_renderPassDescForAddionalDraw->mColour[0].loadAction = Ogre::LoadAction::DontCare;
+		d_renderPassDescForAddionalDraw->mColour[0].clearColour = Ogre::ColourValue(0.5f, 1.0f, 0.0f); //does not matter
+		d_renderPassDescForAddionalDraw->mColour[0].storeAction = Ogre::StoreAction::StoreOrResolve;
+		//Note that resolveTexture should be nullptr if texture isn't msaa.
+		//Also if texture->hasMsaaExplicitResolves() == false, then resolveTexture = texture
+		//is allowed, as the texture will have an internal texture to be used for resolving
+		d_renderPassDescForAddionalDraw->mColour[0].resolveTexture = 0;
+		d_renderPassDescForAddionalDraw->mDepth.texture = d_renderSystem.getDepthBufferFor(textureTarget, textureTarget->getDepthBufferPoolId(), textureTarget->getPreferDepthTexture(), textureTarget->getDesiredDepthBufferFormat());
+		d_renderPassDescForAddionalDraw->mDepth.loadAction = Ogre::LoadAction::Clear;
+		d_renderPassDescForAddionalDraw->mDepth.storeAction = Ogre::StoreAction::DontCare;
+		d_renderPassDescForAddionalDraw->mStencil.texture = nullptr;
+		d_renderPassDescForAddionalDraw->mStencil.loadAction = Ogre::LoadAction::Clear;
+		d_renderPassDescForAddionalDraw->mStencil.storeAction = Ogre::StoreAction::DontCare;
+		d_renderPassDescForAddionalDraw->entriesModified(Ogre::RenderPassDescriptor::All);
+	}
 }
 
 
 void OgreRenderTarget::setOgreViewportDimensions(const Rectf& area)
 {
-    d_ogreViewportDimensions = area;
-
-    if (d_viewport)
-        updateOgreViewportDimensions(d_viewport->getTarget());
-
-    d_viewportValid = false;
+	d_viewportSize = Ogre::Vector4(
+			area.left() / d_textureGpuTarget->getWidth(),
+			area.top() / d_textureGpuTarget->getHeight(),
+			area.getWidth() / d_textureGpuTarget->getWidth(),
+			area.getHeight() / d_textureGpuTarget->getHeight()
+		);
 }
-
-
-void OgreRenderTarget::updateOgreViewportDimensions(
-                                            const Ogre::RenderTarget* const rt)
-{
-    if (rt)
-    {
-        if(d_viewport)
-            d_viewport->setDimensions(
-            d_ogreViewportDimensions.left() / rt->getWidth(),
-            d_ogreViewportDimensions.top() / rt->getHeight(),
-            d_ogreViewportDimensions.getWidth() / rt->getWidth(),
-            d_ogreViewportDimensions.getHeight() / rt->getHeight());
-    }
-}
-
 
 void OgreRenderTarget::activate()
 {
     if (!RenderTarget::d_matrixValid)
         updateMatrix();
 
-    if (!d_viewportValid)
-        updateViewport();
-
-    d_renderSystem._setViewport(d_viewport);
-
     d_owner.setViewProjectionMatrix(RenderTarget::d_matrix);
-#ifdef CEGUI_USE_OGRE_HLMS
-    d_owner.initialiseRenderStateSettings(d_renderTarget);
-#else
-    d_owner.initialiseRenderStateSettings();
-#endif
+	updateRenderPassDescriptor();
+	d_owner.initialiseRenderStateSettings(d_textureGpuTarget, getRenderPassDescriptorForAddionalDraw());
 
     RenderTarget::activate();
 }
 
 void OgreRenderTarget::draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask)
 {
-    buffer.draw(drawModeMask);
+	GeometryBuffer& bufferNoConst = const_cast<GeometryBuffer&>(buffer);
+	OgreGeometryBuffer& ogreBuffer = static_cast<OgreGeometryBuffer&>(bufferNoConst);
+	ogreBuffer.setCurrentRenderTarget(this);
+	
+	ogreBuffer.setFirstDrawOfFrame(false);
+	buffer.draw(drawModeMask);
+
+#if 0
+	ogreBuffer.setCurrentRenderTarget(0);
+#endif
 }
 
 void OgreRenderTarget::draw(const RenderQueue& queue, std::uint32_t drawModeMask)
 {
-    queue.draw(drawModeMask);
+	RenderQueue& queueNoConst = const_cast<RenderQueue&>(queue);
+	RenderQueue::BufferList& buffers = queueNoConst.getBuffers();
+	
+	bool isFirst = true;
+	for(RenderQueue::BufferList::iterator iter = buffers.begin(); iter != buffers.end(); ++iter)
+	{
+		OgreGeometryBuffer* ogreBuffer = static_cast<OgreGeometryBuffer*>(*iter);
+		ogreBuffer->setCurrentRenderTarget(this);
+		ogreBuffer->setFirstDrawOfFrame(isFirst);
+		isFirst = false;
+	}
+
+	queue.draw(drawModeMask);
+
+#if 0
+	for(RenderQueue::BufferList::iterator iter = buffers.begin(); iter != buffers.end(); ++iter)
+	{
+		OgreGeometryBuffer* ogreBuffer = static_cast<OgreGeometryBuffer*>(*iter);
+		ogreBuffer->setCurrentRenderTarget(0);
+	}
+#endif
 }
 
 void OgreRenderTarget::unprojectPoint(const GeometryBuffer& buff,
@@ -195,32 +258,10 @@ void OgreRenderTarget::updateMatrix() const
         throw RendererException("An unsupported RenderSystem is being used by Ogre. Please contact the CEGUI team.");
 }
 
-
-void OgreRenderTarget::updateViewport()
-{
-    if (!d_viewport)
-    {
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
-
-        d_viewport = OGRE_NEW Ogre::Viewport(d_renderTarget, 0, 0, 1, 1);
-#else
-        d_viewport = OGRE_NEW Ogre::Viewport(0, d_renderTarget, 0, 0, 1, 1, 0);
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
-
-        updateOgreViewportDimensions(d_renderTarget);
-    }
-
-    d_viewport->_updateDimensions();
-
-    d_viewportValid = true;
-}
-
-
 OgreRenderer& OgreRenderTarget::getOwner()
 {
     return d_owner;
 }
-
 
 void OgreRenderTarget::setArea(const Rectf& area)
 {
@@ -232,3 +273,213 @@ void OgreRenderTarget::setArea(const Rectf& area)
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/RenderTarget.h"
+#include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
+#include "CEGUI/Exceptions.h"
+#include "CEGUI/RenderQueue.h"
+
+#include <OgreRenderSystem.h>
+#include <OgreRenderTarget.h>
+#include <OgreCamera.h>
+#include <OgreViewport.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+
+
+	OgreRenderTarget::OgreRenderTarget(OgreRenderer& owner,
+		Ogre::RenderSystem& rs) :
+		d_owner(owner),
+		d_renderSystem(rs),
+		d_renderTarget(0),
+		d_viewport(0),
+		d_ogreViewportDimensions(0, 0, 0, 0),
+		d_viewportValid(false)
+	{
+	}
+
+
+	OgreRenderTarget::~OgreRenderTarget()
+	{
+		delete d_viewport;
+	}
+
+
+	void OgreRenderTarget::setOgreViewportDimensions(const Rectf& area)
+	{
+		d_ogreViewportDimensions = area;
+
+		if(d_viewport)
+			updateOgreViewportDimensions(d_viewport->getTarget());
+
+		d_viewportValid = false;
+	}
+
+
+	void OgreRenderTarget::updateOgreViewportDimensions(
+		const Ogre::RenderTarget* const rt)
+	{
+		if(rt)
+		{
+			if(d_viewport)
+				d_viewport->setDimensions(
+					d_ogreViewportDimensions.left() / rt->getWidth(),
+					d_ogreViewportDimensions.top() / rt->getHeight(),
+					d_ogreViewportDimensions.getWidth() / rt->getWidth(),
+					d_ogreViewportDimensions.getHeight() / rt->getHeight());
+		}
+	}
+
+
+	void OgreRenderTarget::activate()
+	{
+		if(!RenderTarget::d_matrixValid)
+			updateMatrix();
+
+		if(!d_viewportValid)
+			updateViewport();
+
+		d_renderSystem._setViewport(d_viewport);
+
+		d_owner.setViewProjectionMatrix(RenderTarget::d_matrix);
+#ifdef CEGUI_USE_OGRE_HLMS
+		d_owner.initialiseRenderStateSettings(d_renderTarget);
+#else
+		d_owner.initialiseRenderStateSettings();
+#endif
+
+		RenderTarget::activate();
+	}
+
+	void OgreRenderTarget::draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask)
+	{
+		buffer.draw(drawModeMask);
+	}
+
+	void OgreRenderTarget::draw(const RenderQueue& queue, std::uint32_t drawModeMask)
+	{
+		queue.draw(drawModeMask);
+	}
+
+	void OgreRenderTarget::unprojectPoint(const GeometryBuffer& buff,
+		const glm::vec2& p_in,
+		glm::vec2& p_out) const
+	{
+		if(!RenderTarget::d_matrixValid)
+			updateMatrix();
+
+		const OgreGeometryBuffer& gb = static_cast<const OgreGeometryBuffer&>(buff);
+
+		const Ogre::Real midx = RenderTarget::d_area.getWidth() * 0.5f;
+		const Ogre::Real midy = RenderTarget::d_area.getHeight() * 0.5f;
+
+		// viewport matrix
+		const Ogre::Matrix4 vpmat(
+			midx, 0, 0, RenderTarget::d_area.left() + midx,
+			0, -midy, 0, RenderTarget::d_area.top() + midy,
+			0, 0, 1, 0,
+			0, 0, 0, 1
+		);
+
+		// matrices used for projecting and unprojecting points
+
+		const Ogre::Matrix4 proj(OgreRenderer::glmToOgreMatrix(gb.getModelMatrix() * RenderTarget::d_matrix) * vpmat);
+		const Ogre::Matrix4 unproj(proj.inverse());
+
+		Ogre::Vector3 in;
+
+		// unproject the ends of the ray
+		in.x = midx;
+		in.y = midy;
+		in.z = -RenderTarget::d_viewDistance;
+		const Ogre::Vector3 r1(unproj * in);
+		in.x = p_in.x;
+		in.y = p_in.y;
+		in.z = 0;
+		// calculate vector of picking ray
+		const Ogre::Vector3 rv(r1 - unproj * in);
+
+		// project points to orientate them with GeometryBuffer plane
+		in.x = 0.0;
+		in.y = 0.0;
+		const Ogre::Vector3 p1(proj * in);
+		in.x = 1.0;
+		in.y = 0.0;
+		const Ogre::Vector3 p2(proj * in);
+		in.x = 0.0;
+		in.y = 1.0;
+		const Ogre::Vector3 p3(proj * in);
+
+		// calculate the plane normal
+		const Ogre::Vector3 pn((p2 - p1).crossProduct(p3 - p1));
+		// calculate distance from origin
+		const Ogre::Real plen = pn.length();
+		const Ogre::Real dist = -(p1.x * (pn.x / plen) +
+			p1.y * (pn.y / plen) +
+			p1.z * (pn.z / plen));
+
+		// calculate intersection of ray and plane
+		const Ogre::Real pn_dot_rv = pn.dotProduct(rv);
+		const Ogre::Real tmp = pn_dot_rv != 0.0 ?
+			(pn.dotProduct(r1) + dist) / pn_dot_rv :
+			0.0f;
+
+		p_out.x = static_cast<float>(r1.x - rv.x * tmp);
+		p_out.y = static_cast<float>(r1.y - rv.y * tmp);
+	}
+
+
+	void OgreRenderTarget::updateMatrix() const
+	{
+		if(d_owner.usesOpenGL())
+			RenderTarget::updateMatrix(RenderTarget::createViewProjMatrixForOpenGL());
+		else if(d_owner.usesDirect3D())
+			RenderTarget::updateMatrix(RenderTarget::createViewProjMatrixForDirect3D());
+		else
+			throw RendererException("An unsupported RenderSystem is being used by Ogre. Please contact the CEGUI team.");
+	}
+
+
+	void OgreRenderTarget::updateViewport()
+	{
+		if(!d_viewport)
+		{
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+
+			d_viewport = OGRE_NEW Ogre::Viewport(d_renderTarget, 0, 0, 1, 1);
+#else
+			d_viewport = OGRE_NEW Ogre::Viewport(0, d_renderTarget, 0, 0, 1, 1, 0);
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+
+			updateOgreViewportDimensions(d_renderTarget);
+		}
+
+		d_viewport->_updateDimensions();
+
+		d_viewportValid = true;
+	}
+
+
+	OgreRenderer& OgreRenderTarget::getOwner()
+	{
+		return d_owner;
+	}
+
+
+	void OgreRenderTarget::setArea(const Rectf& area)
+	{
+		setOgreViewportDimensions(area);
+
+		RenderTarget::setArea(area);
+	}
+
+	//----------------------------------------------------------------------------//
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -25,6 +25,8 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/Renderer.h"
+
+#ifdef CEGUI_OGRE_NEXT
 #include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
 #include "CEGUI/RendererModules/Ogre/TextureTarget.h"
 #include "CEGUI/RendererModules/Ogre/Texture.h"
@@ -35,10 +37,14 @@
 #include "CEGUI/RendererModules/Ogre/ResourceProvider.h"
 #include "CEGUI/RendererModules/Ogre/ImageCodec.h"
 #include "CEGUI/Logger.h"
+#include "CEGUI/BitmapImage.h"
+#include "CEGUI/ImageManager.h"
+#include "CEGUI/Window.h"
+#include "CEGUI/WindowManager.h"
 
 #include <OgreRoot.h>
 #include <OgreRenderSystem.h>
-#include <OgreRenderWindow.h>
+#include <OgreWindow.h>
 #include <OgreHighLevelGpuProgramManager.h>
 #include <OgreHighLevelGpuProgram.h>
 #include <OgreGpuProgramManager.h>
@@ -47,8 +53,8 @@
 #include <OgreViewport.h>
 #include <OgreCamera.h>
 #include <OgreHardwareVertexBuffer.h>
+#include <OgreTextureGpuManager.h>
 
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
 #include <Compositor/OgreCompositorManager2.h>
 #include <Compositor/OgreCompositorCommon.h>
 #include <Compositor/OgreCompositorWorkspaceDef.h>
@@ -57,19 +63,12 @@
 #include <Compositor/Pass/PassClear/OgreCompositorPassClear.h>
 #include <Compositor/Pass/PassScene/OgreCompositorPassScene.h>
 #include <Compositor/OgreCompositorWorkspaceListener.h>
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
 
-#ifdef CEGUI_USE_OGRE_HLMS
 #include <OgreHlmsManager.h>
 #include <OgreHlmsDatablock.h>
 #include <OgrePsoCacheHelper.h>
-#endif
+#include <OgreProfiler.h>
 
-#ifndef CEGUI_USE_OGRE_HLMS
-#if OGRE_VERSION >= 0x10800
-#   include "OgreRTShaderConfig.h"
-#endif
-#endif
 
 #if OGRE_VERSION >= 0x020100
 #include <CommandBuffer/OgreCbDrawCall.h>
@@ -82,6 +81,8 @@
 #include "glm/gtc/type_ptr.hpp"
 
 #include <unordered_map>
+#include <sstream>
+#include <fstream>
 
 #define VERTEXBUFFER_POOL_SIZE_STARTCLEAR           60
 
@@ -89,7 +90,6 @@
 namespace CEGUI
 {
 //----------------------------------------------------------------------------//
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
 // The new method will be used
 // Internal Ogre::CompositorWorkspaceListener. This is how the renderer gets notified
 // of workspaces that need rendering
@@ -105,31 +105,13 @@ public:
 
     virtual void passPreExecute(Ogre::CompositorPass *pass);
 
+	CEGUI::GUIContext* mGUIContextToRender; //If set, only this GUIContext is rendered
+
 private:
     bool d_enabled;
     OgreRenderer* d_owner;
-
 };
 
-#else // Use the old method
-// Internal Ogre::FrameListener based class.  This is how we noew hook into the
-// rendering process (as opposed to render queues previously)
-static class OgreGUIFrameListener : public Ogre::FrameListener
-{
-public:
-    OgreGUIFrameListener();
-
-    void setCEGUIRenderEnabled(bool enabled);
-    bool isCEGUIRenderEnabled() const;
-
-    bool frameRenderingQueued(const Ogre::FrameEvent& evt);
-
-private:
-    bool d_enabled;
-
-} S_frameListener;
-
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
 //----------------------------------------------------------------------------//
 //! container type used to hold TextureTargets we create.
 typedef std::vector<TextureTarget*> TextureTargetList;
@@ -138,11 +120,7 @@ typedef std::vector<OgreGeometryBuffer*> GeometryBufferList;
 //! container type used to hold Textures we create.
 typedef std::unordered_map<String, OgreTexture*> TextureMap;
 
-#ifdef CEGUI_USE_OGRE_HLMS
 typedef Ogre::v1::HardwareVertexBufferSharedPtr UsedOgreHWBuffer;
-#else
-typedef Ogre::HardwareVertexBufferSharedPtr UsedOgreHWBuffer;
-#endif //CEGUI_USE_OGRE_HLMS
 
 //----------------------------------------------------------------------------//
 // Implementation data for the OgreRenderer
@@ -152,30 +130,23 @@ struct OgreRenderer_impl
         //! TODO: Currently there is no way to do this easily using Ogre
         d_maxTextureSize(2048),
         d_ogreRoot(Ogre::Root::getSingletonPtr()),
-#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
-        d_previousVP(0),
-#else
         d_frameListener(0),
         d_dummyScene(0),
         d_dummyCamera(0),
         d_workspace(0),
-#endif
-#ifdef CEGUI_USE_OGRE_HLMS
-        //d_renderTarget(nullptr),
         d_hlmsMacroblock(nullptr),
         d_hlmsBlendblock(nullptr),
         d_hlmsSamplerblock(nullptr),
-#endif
-        d_activeBlendMode(BlendMode::Invalid),
+		d_activeBlendMode(BlendMode::Invalid),
         d_makeFrameControlCalls(true),
         d_useGLSL(false),
         d_useGLSLES(false),
         d_useHLSL(false),
         d_useGLSLCore(false),
         d_texturedShaderWrapper(0),
-        d_colouredShaderWrapper(0)
+        d_colouredShaderWrapper(0),
+		d_RenderingMode(OgreRenderer::RenderingMode_RenderAllCeguiGUIContexts)
         {}
-
 
     //! String holding the renderer identification text.
     static String d_rendererID;
@@ -195,13 +166,6 @@ struct OgreRenderer_impl
     Ogre::Root* d_ogreRoot;
     //! Pointer to the render system for Ogre.
     Ogre::RenderSystem* d_renderSystem;
-#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
-    //! Pointer to the previous viewport set in render system.
-    Ogre::Viewport* d_previousVP;
-    //! Previous projection matrix set on render system.
-    Ogre::Matrix4 d_previousProjMatrix;
-#else
-
     //! This is used to get notifications when our scene is rendered
     //! no longer static because it requires a pointer to this
     OgreGUIRenderQueueListener* d_frameListener;
@@ -220,9 +184,6 @@ struct OgreRenderer_impl
     //! initializing the Compositor if it isn't already
     static bool s_compositorResourcesInitialized;
 
-#endif
-
-#ifdef CEGUI_USE_OGRE_HLMS
     //! OGRE render target
     //Ogre::RenderTarget* d_renderTarget;
     //! HLMS block used to set macro parameters
@@ -234,7 +195,6 @@ struct OgreRenderer_impl
 
     //! HLMS cache used to store pso
     Ogre::SharedPtr<Ogre::PsoCacheHelper> d_hlmsCache;
-#endif
 
     //! What we think is the current blend mode to use
     BlendMode d_activeBlendMode;
@@ -249,31 +209,66 @@ struct OgreRenderer_impl
     //! Whether we use the ARB glsl shaders or the OpenGL 3.2 Core shader profile (140 core)
     bool d_useGLSLCore;
 
-#ifdef CEGUI_USE_OGRE_HLMS
     //! Vector containing vertex buffers that can be reused
     std::vector<Ogre::v1::HardwareVertexBufferSharedPtr> d_vbPool;
-#else
-    //! Vector containing vertex buffers that can be reused
-    std::vector<Ogre::HardwareVertexBufferSharedPtr> d_vbPool;
-#endif //CEGUI_USE_OGRE_HLMS
 
     OgreShaderWrapper* d_texturedShaderWrapper;
     OgreShaderWrapper* d_colouredShaderWrapper;
+
+	OgreRenderer::RenderingModes d_RenderingMode;
+	//---------------------------------------------
 };
 
 //----------------------------------------------------------------------------//
 String OgreRenderer_impl::d_rendererID(
-"CEGUI::OgreRenderer - OGRE based 3rd generation renderer module"
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
-" with Ogre::Compositor2 enabled"
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
-".");
+"CEGUI::OgreRenderer - OGRE based 3rd generation renderer module.");
 
-#if defined(CEGUI_USE_OGRE_COMPOSITOR2)
 int OgreRenderer_impl::s_createdSceneNumber = 0;
 bool OgreRenderer_impl::s_compositorResourcesInitialized = false;
-#endif
 
+//----------------------------------------------------------------------------//
+void OgreRenderer::configureCeguiWindowForRTT(CEGUI::Window* window, const std::string& ogreTextureName, float textureWidth, float textureHeight, bool isTextureTargetVerticallyFlipped)
+{
+	// We create a CEGUI Texture using the renderer you use:
+	CEGUI::Texture* texture;
+	if(isTextureDefined(ogreTextureName + "_CEGUI"))
+		texture = &getTexture(ogreTextureName + "_CEGUI");
+	else
+		texture = &createTexture(ogreTextureName + "_CEGUI");
+
+	// Now we need to cast it to the CEGUI::Texture superclass which matches your Renderer. This can be CEGUI::OgreTexture or CEGUI::OpenGLTexture, depending on the renderer you use in your application
+	CEGUI::OgreTexture& rendererTexture = static_cast<CEGUI::OgreTexture&>(*texture);
+
+	// Now we can set the appropriate Ogre Texture for our CEGUI Texture	
+	Ogre::TextureGpu* ogreTextureGpu = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager()->findTextureNoThrow(ogreTextureName);
+
+	if(!ogreTextureGpu)
+		throw std::runtime_error("could not find RTT-texture (OgreRenderer::configureCeguiWindowForRTT)");
+
+	rendererTexture.setOgreTexture(ogreTextureGpu, false);
+
+	// We create a BasicImage and set the Texture
+	CEGUI::BitmapImage* image;
+	if(CEGUI::ImageManager::getSingleton().isDefined(ogreTextureName))
+		image = static_cast<CEGUI::BitmapImage*>(&CEGUI::ImageManager::getSingleton().get(ogreTextureName));
+	else
+		image = static_cast<CEGUI::BitmapImage*>(&CEGUI::ImageManager::getSingleton().create("BitmapImage", ogreTextureName));
+
+	image->setTexture(&rendererTexture);
+
+	CEGUI::Rectf imageArea;
+	//Flipping is necessary due to differences between renderers regarding top or bottom being the origin
+	//bool isTextureTargetVerticallyFlipped = renderTextureTarget->isRenderingInverted();
+	if(isTextureTargetVerticallyFlipped)
+		imageArea = CEGUI::Rectf(0.0f, textureHeight, textureWidth, 0.0f);
+	else
+		imageArea = CEGUI::Rectf(0.0f, 0.0f, textureWidth, textureHeight);
+
+	image->setImageArea(imageArea);
+	image->setAutoScaled(CEGUI::AutoScaledMode::Disabled);
+
+	window->setProperty("Image", ogreTextureName);
+}
 //----------------------------------------------------------------------------//
 OgreRenderer& OgreRenderer::bootstrapSystem(const int abi)
 {
@@ -283,9 +278,7 @@ OgreRenderer& OgreRenderer::bootstrapSystem(const int abi)
         throw InvalidRequestException(
         "CEGUI::System object is already initialised.");
 
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
     createOgreCompositorResources();
-#endif
 
     OgreRenderer& renderer = create();
     OgreResourceProvider& rp = createOgreResourceProvider();
@@ -296,7 +289,7 @@ OgreRenderer& OgreRenderer::bootstrapSystem(const int abi)
 }
 
 //----------------------------------------------------------------------------//
-OgreRenderer& OgreRenderer::bootstrapSystem(Ogre::RenderTarget& target,
+OgreRenderer& OgreRenderer::bootstrapSystem(Ogre::Window* target,
                                             const int abi)
 {
     System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
@@ -305,9 +298,7 @@ OgreRenderer& OgreRenderer::bootstrapSystem(Ogre::RenderTarget& target,
         throw InvalidRequestException(
             "CEGUI::System object is already initialised.");
 
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
     createOgreCompositorResources();
-#endif
 
     OgreRenderer& renderer = OgreRenderer::create(target);
     OgreResourceProvider& rp = createOgreResourceProvider();
@@ -346,7 +337,7 @@ OgreRenderer& OgreRenderer::create(const int abi)
 }
 
 //----------------------------------------------------------------------------//
-OgreRenderer& OgreRenderer::create(Ogre::RenderTarget& target,
+OgreRenderer& OgreRenderer::create(Ogre::Window* target,
                                    const int abi)
 {
     System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
@@ -367,22 +358,20 @@ OgreResourceProvider& OgreRenderer::createOgreResourceProvider()
 }
 
 //----------------------------------------------------------------------------//
-OgreRenderer& OgreRenderer::registerWindow(OgreRenderer& /*main_window*/,
+/*OgreRenderer& OgreRenderer::registerWindow(OgreRenderer& main_window,
     Ogre::RenderTarget &new_window)
 {
     // Link the second renderer to the first for them to share some resources
 
     return *new OgreRenderer(new_window);
-}
+}*/
 
 //----------------------------------------------------------------------------//
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
 void OgreRenderer::createOgreCompositorResources()
 {
     // Create all the definitions for the workspaces and nodes
 
-    Ogre::CompositorManager2* manager = Ogre::Root::getSingleton().
-        getCompositorManager2();
+    Ogre::CompositorManager2* manager = Ogre::Root::getSingleton().getCompositorManager2();
 
     // We want this to fail if it isn't initialized
     if (!manager)
@@ -391,59 +380,43 @@ void OgreRenderer::createOgreCompositorResources()
         "you must call Ogre::Root::initialiseCompositor() after "
         "creating at least one window.");
 
-    Ogre::CompositorWorkspaceDef* templatedworkspace =
-        manager->addWorkspaceDefinition("CEGUI_workspace");
+    Ogre::CompositorWorkspaceDef* templatedworkspace = manager->addWorkspaceDefinition("CEGUI_workspace");
 
     // Create a node for rendering on top of everything
-    Ogre::CompositorNodeDef* rendernode =
-        manager->addNodeDefinition("CEGUIRenderNode");
+    Ogre::CompositorNodeDef* rendernode = manager->addNodeDefinition("CEGUIRenderNode");
 
     // Use the render target passed from the workspace for rendering on top of
     // everything
-    rendernode->addTextureSourceName("renderwindow", 0,
-        Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+    rendernode->addTextureSourceName("renderwindow", 0, Ogre::TextureDefinitionBase::TEXTURE_INPUT);
 
     rendernode->setNumTargetPass(1);
 
     // Pass for it
-    Ogre::CompositorTargetDef* targetpasses =
-        rendernode->addTargetPass("renderwindow");
+    Ogre::CompositorTargetDef* targetpasses = rendernode->addTargetPass("renderwindow");
     targetpasses->setNumPasses(2);
 
-    Ogre::CompositorPassClearDef* clearpass =
-        static_cast<Ogre::CompositorPassClearDef*>(targetpasses->
-            addPass(Ogre::PASS_CLEAR));
-
+    Ogre::CompositorPassClearDef* clearpass = static_cast<Ogre::CompositorPassClearDef*>(targetpasses->addPass(Ogre::PASS_CLEAR));
+	
     // Only clear depth and stencil since we are rendering on top
     // of an existing image
-    clearpass->mClearBufferFlags = Ogre::FBT_DEPTH | Ogre::FBT_STENCIL;
+	clearpass->setBuffersToClear(Ogre::RenderPassDescriptor::Depth | Ogre::RenderPassDescriptor::Stencil); 
 
     // Now the render scene pass during which the render queue listener
     // should render the GUI
-    Ogre::CompositorPassSceneDef* scenepass =
-        static_cast<Ogre::CompositorPassSceneDef*>(targetpasses->
-            addPass(Ogre::PASS_SCENE));
-#ifdef CEGUI_USE_OGRE_HLMS
-    (void)scenepass;
+    Ogre::CompositorPassSceneDef* scenepass = static_cast<Ogre::CompositorPassSceneDef*>(targetpasses->addPass(Ogre::PASS_SCENE));
+
+#if(OGRE_PROFILING == OGRE_PROFILING_INTERNAL)
+	clearpass->mProfilingId = "CLEAR_CEGUI";
+	scenepass->mProfilingId = "SCENE_CEGUI";
+#endif
 
     // Connect the main render target to the node
     templatedworkspace->connectExternal(0, "CEGUIRenderNode", 0);
-
-#else
-    // Just render the overlay group since it is the only one used
-    scenepass->mFirstRQ = Ogre::RENDER_QUEUE_OVERLAY;
-    scenepass->mLastRQ = Ogre::RENDER_QUEUE_OVERLAY+1;
-
-    // Connect the main render target to the node
-    templatedworkspace->connectOutput("CEGUIRenderNode", 0);
-#endif //CEGUI_USE_OGRE_HLMS
 
     // Resources now created
     OgreRenderer_impl::s_compositorResourcesInitialized = true;
 
 }
-#endif
-
 //----------------------------------------------------------------------------//
 void OgreRenderer::destroyOgreResourceProvider(OgreResourceProvider& rp)
 {
@@ -485,24 +458,25 @@ Ogre::Matrix4 OgreRenderer::glmToOgreMatrix(const glm::mat4& matrix)
 //----------------------------------------------------------------------------//
 void OgreRenderer::setRenderingEnabled(const bool enabled)
 {
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
-    d_pimpl->d_frameListener->setCEGUIRenderEnabled(enabled);
-    d_pimpl->d_workspace->setEnabled(false);
-#else
-    S_frameListener.setCEGUIRenderEnabled(enabled);
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
+	throw std::runtime_error("Error: function OgreRenderer::setRenderingEnabled is depreciated. Use OgreRenderer::setRenderMode instead");
 }
 
 //----------------------------------------------------------------------------//
 bool OgreRenderer::isRenderingEnabled() const
 {
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
-    return d_pimpl->d_frameListener->isCEGUIRenderEnabled();
-#else
-    return S_frameListener.isCEGUIRenderEnabled();
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
+    return (d_pimpl->d_RenderingMode != OgreRenderer::RenderingMode_Disabled);
 }
-
+//----------------------------------------------------------------------------//
+void OgreRenderer::setRenderingMode(OgreRenderer::RenderingModes renderingMode)
+{
+	d_pimpl->d_RenderingMode = renderingMode;
+	d_pimpl->d_workspace->setEnabled(renderingMode != OgreRenderer::RenderingMode_Disabled);
+}
+//----------------------------------------------------------------------------//
+OgreRenderer::RenderingModes OgreRenderer::getRenderingMode() const
+{
+	return d_pimpl->d_RenderingMode;
+}
 //----------------------------------------------------------------------------//
 RenderTarget& OgreRenderer::getDefaultRenderTarget()
 {
@@ -579,7 +553,7 @@ Texture& OgreRenderer::createTexture(const String& name, const Sizef& size)
 }
 
 //----------------------------------------------------------------------------//
-Texture& OgreRenderer::createTexture(const String& name, Ogre::TexturePtr& tex,
+Texture& OgreRenderer::createTexture(const String& name, Ogre::TextureGpu* tex,
                                      bool take_ownership)
 {
     throwIfNameExists(name);
@@ -662,16 +636,6 @@ bool OgreRenderer::isTextureDefined(const String& name) const
 //----------------------------------------------------------------------------//
 void OgreRenderer::beginRendering()
 {
-    #if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
-        if ( !d_pimpl->d_previousVP )
-        {
-            d_pimpl->d_previousVP = d_pimpl->d_renderSystem->_getViewport();
-            if ( d_pimpl->d_previousVP && d_pimpl->d_previousVP->getCamera() )
-                d_pimpl->d_previousProjMatrix =
-                    d_pimpl->d_previousVP->getCamera()->getProjectionMatrixRS();
-        }
-    #endif
-
     if (d_pimpl->d_makeFrameControlCalls)
         d_pimpl->d_renderSystem->_beginFrame();
 }
@@ -681,23 +645,6 @@ void OgreRenderer::endRendering()
 {
     if (d_pimpl->d_makeFrameControlCalls)
         d_pimpl->d_renderSystem->_endFrame();
-
-    #if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
-        if ( d_pimpl->d_previousVP )
-        {
-            d_pimpl->d_renderSystem->_setViewport(d_pimpl->d_previousVP);
-
-            if ( d_pimpl->d_previousVP->getCamera() )
-            {
-                d_pimpl->d_renderSystem->_setProjectionMatrix(
-                    d_pimpl->d_previousProjMatrix);
-                d_pimpl->d_renderSystem->_setViewMatrix(
-                    d_pimpl->d_previousVP->getCamera()->getViewMatrix());
-            }
-            d_pimpl->d_previousVP = 0;
-            d_pimpl->d_previousProjMatrix = Ogre::Matrix4::IDENTITY;
-        }
-    #endif
 }
 
 //----------------------------------------------------------------------------//
@@ -724,18 +671,18 @@ OgreRenderer::OgreRenderer() :
     checkOgreInitialised();
 
     // get auto created window
-    Ogre::RenderWindow* rwnd = d_pimpl->d_ogreRoot->getAutoCreatedWindow();
+    Ogre::Window* rwnd = d_pimpl->d_ogreRoot->getAutoCreatedWindow();
     if (!rwnd)
         throw RendererException(
             "Ogre was not initialised to automatically create a window, you "
             "should therefore be explicitly specifying a Ogre::RenderTarget in "
             "the OgreRenderer::create function.");
 
-    constructor_impl(*rwnd);
+    constructor_impl(rwnd);
 }
 
 //----------------------------------------------------------------------------//
-OgreRenderer::OgreRenderer(Ogre::RenderTarget& target) :
+OgreRenderer::OgreRenderer(Ogre::Window* target) :
     d_pimpl(new OgreRenderer_impl())
 {
     checkOgreInitialised();
@@ -746,9 +693,8 @@ OgreRenderer::OgreRenderer(Ogre::RenderTarget& target) :
 //----------------------------------------------------------------------------//
 OgreRenderer::~OgreRenderer()
 {
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
     // Remove the listener and then delete the scene
-    d_pimpl->d_workspace->setListener(0);
+    d_pimpl->d_workspace->removeListener(d_pimpl->d_frameListener);
 
     d_pimpl->d_ogreRoot->destroySceneManager(d_pimpl->d_dummyScene);
 
@@ -761,15 +707,9 @@ OgreRenderer::~OgreRenderer()
 
     d_pimpl->d_workspace = 0;
 
-#else
-    d_pimpl->d_ogreRoot->removeFrameListener(&S_frameListener);
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
-
     cleanupShaders();
 
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
     delete d_pimpl->d_frameListener;
-#endif
 
     destroyAllGeometryBuffers();
     destroyAllTextureTargets();
@@ -793,12 +733,12 @@ void OgreRenderer::checkOgreInitialised()
 }
 
 //----------------------------------------------------------------------------//
-void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
+void OgreRenderer::constructor_impl(Ogre::Window* target)
 {
     d_pimpl->d_renderSystem = d_pimpl->d_ogreRoot->getRenderSystem();
 
-    d_pimpl->d_displaySize.d_width  = static_cast<float>(target.getWidth());
-    d_pimpl->d_displaySize.d_height = static_cast<float>(target.getHeight());
+    d_pimpl->d_displaySize.d_width  = static_cast<float>(target->getWidth());
+    d_pimpl->d_displaySize.d_height = static_cast<float>(target->getHeight());
 
     //! Checking if OpenGL > 3.2 supported
     if (d_pimpl->d_renderSystem->getName().find("OpenGL 3+") != Ogre::String::npos)
@@ -807,19 +747,9 @@ void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
     }
 
     // create default target & rendering root (surface) that uses it
-    d_pimpl->d_defaultTarget =
-        new OgreWindowTarget(*this, *d_pimpl->d_renderSystem, target);
-
-#ifndef CEGUI_USE_OGRE_HLMS
-#if OGRE_VERSION >= 0x10800
-    #ifndef RTSHADER_SYSTEM_BUILD_CORE_SHADERS
-        throw RendererException("RT Shader System not available. However CEGUI relies on shaders for rendering. ");
-    #endif
-#endif
-#endif //CEGUI_USE_OGRE_HLMS
+    d_pimpl->d_defaultTarget = new OgreWindowTarget(*this, *d_pimpl->d_renderSystem, target);
 
     // hook into the rendering process
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
 
     // Some automatic bootstrapping
     if (!OgreRenderer_impl::s_compositorResourcesInitialized)
@@ -833,7 +763,7 @@ void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
         OgreRenderer_impl::s_createdSceneNumber++;
 
     d_pimpl->d_dummyScene = d_pimpl->d_ogreRoot->createSceneManager(
-        Ogre::ST_INTERIOR, 1, Ogre::INSTANCING_CULLING_SINGLETHREAD,
+        Ogre::ST_INTERIOR, 1, 
         scene_name.str());
 
     // Unused camera for the scene
@@ -850,13 +780,9 @@ void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
 
     // The -1 should guarantee this to be rendered last on top of everything
     d_pimpl->d_workspace = manager->addWorkspace(d_pimpl->d_dummyScene,
-        &target, d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
+        target->getTexture(), d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
 
-    d_pimpl->d_workspace->setListener(d_pimpl->d_frameListener);
-
-#else
-    d_pimpl->d_ogreRoot->addFrameListener(&S_frameListener);
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
+    d_pimpl->d_workspace->addListener(d_pimpl->d_frameListener);
 
     initialiseShaders();
 }
@@ -864,7 +790,6 @@ void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
 //----------------------------------------------------------------------------//
 void OgreRenderer::initialiseShaders()
 {
-#ifdef CEGUI_USE_OGRE_HLMS
     Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
 
     // Macro block
@@ -892,8 +817,6 @@ void OgreRenderer::initialiseShaders()
     // PSO
     d_pimpl->d_hlmsCache = Ogre::SharedPtr<Ogre::PsoCacheHelper>(
         new Ogre::PsoCacheHelper(d_pimpl->d_renderSystem));
-
-#endif
 
     Ogre::HighLevelGpuProgramPtr texture_vs;
     Ogre::HighLevelGpuProgramPtr texture_ps;
@@ -1087,8 +1010,6 @@ void OgreRenderer::cleanupShaders()
     delete d_pimpl->d_texturedShaderWrapper;
     delete d_pimpl->d_colouredShaderWrapper;
 
-#ifdef CEGUI_USE_OGRE_HLMS
-
     Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
 
     d_pimpl->d_hlmsCache.setNull();
@@ -1099,10 +1020,6 @@ void OgreRenderer::cleanupShaders()
         hlmsManager->destroyMacroblock(d_pimpl->d_hlmsMacroblock);
     if (d_pimpl->d_hlmsSamplerblock != nullptr)
         hlmsManager->destroySamplerblock(d_pimpl->d_hlmsSamplerblock);
-
-
-
-#endif //CEGUI_USE_OGRE_HLMS
 }
 
 //----------------------------------------------------------------------------//
@@ -1124,20 +1041,15 @@ void OgreRenderer::setDisplaySize(const Sizef& sz)
 void OgreRenderer::setupRenderingBlendMode(const BlendMode mode,
                                            bool force)
 {
-#ifdef CEGUI_USE_OGRE_HLMS
     // Enable force if no blend block has been created
     if (!d_pimpl->d_hlmsBlendblock)
         force = true;
-
-#endif //CEGUI_USE_OGRE_HLMS
 
     // do nothing if mode appears current (and is not forced)
     if ((d_pimpl->d_activeBlendMode == mode) && !force)
         return;
 
     d_pimpl->d_activeBlendMode = mode;
-
-#ifdef CEGUI_USE_OGRE_HLMS
 
     Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
 
@@ -1158,25 +1070,8 @@ void OgreRenderer::setupRenderingBlendMode(const BlendMode mode,
         blendblock.mDestBlendFactorAlpha = Ogre::SBF_ONE;
     }
     d_pimpl->d_hlmsBlendblock = hlmsManager->getBlendblock(blendblock);
-
-
-#else
-    using namespace Ogre;
-
-    if (d_pimpl->d_activeBlendMode == BlendMode::RttPremultiplied)
-        d_pimpl->d_renderSystem->_setSceneBlending(SBF_ONE,
-            SBF_ONE_MINUS_SOURCE_ALPHA);
-    else
-        d_pimpl->d_renderSystem->
-            _setSeparateSceneBlending(SBF_SOURCE_ALPHA,
-                SBF_ONE_MINUS_SOURCE_ALPHA,
-                SBF_ONE_MINUS_DEST_ALPHA,
-                SBF_ONE);
-
-#endif //CEGUI_USE_OGRE_HLMS
 }
 
-#ifdef CEGUI_USE_OGRE_HLMS
 void OgreRenderer::bindPSO(const Ogre::v1::RenderOperation render_operation)
 {
     // Blendmode must be set before
@@ -1194,7 +1089,15 @@ void OgreRenderer::bindPSO(const Ogre::v1::RenderOperation render_operation)
 	#endif
 
     // This should have all the rendering settings
-    Ogre::HlmsPso* pso = d_pimpl->d_hlmsCache->getPso();
+	Ogre::HlmsPso* pso = d_pimpl->d_hlmsCache->getPso();
+	/*pso = 0;
+	
+	{
+		const Ogre::uint32 renderableHash = d_pimpl->d_hlmsCache->getRenderableHash();
+		pso = d_pimpl->d_hlmsCache->getPso(renderableHash, true);
+	}*/
+
+	//Ogre::HlmsPso* pso = d_pimpl->d_hlmsCache->getPso((Ogre::uint32)0, true); //always request same Pso, otherwise Ogre2.1 will get out of control and create new Pso's over and other first causing slowdown and ultimatively application crash
 
     // Bind it
     d_pimpl->d_renderSystem->_setPipelineStateObject(pso);
@@ -1215,8 +1118,6 @@ void OgreRenderer::setGPUPrograms(const Ogre::HighLevelGpuProgramPtr &vs,
     d_pimpl->d_hlmsCache->setPixelShader(psConverted);
 }
 
-#endif //CEGUI_USE_OGRE_HLMS
-
 //----------------------------------------------------------------------------//
 void OgreRenderer::setFrameControlExecutionEnabled(const bool enabled)
 {
@@ -1225,7 +1126,7 @@ void OgreRenderer::setFrameControlExecutionEnabled(const bool enabled)
     // default rendering requires _beginFrame and _endFrame calls be made,
     // so if we're disabling those we must also disable default rendering.
     if (!d_pimpl->d_makeFrameControlCalls)
-        setRenderingEnabled(false);
+        setRenderingMode(OgreRenderer::RenderingMode_Disabled);
 }
 
 //----------------------------------------------------------------------------//
@@ -1259,60 +1160,22 @@ static const Ogre::LayerBlendModeEx S_alphaBlendMode =
 };
 
 //----------------------------------------------------------------------------//
-#ifndef CEGUI_USE_OGRE_HLMS
-static const Ogre::TextureUnitState::UVWAddressingMode S_textureAddressMode =
-    {
-        Ogre::TextureUnitState::TAM_CLAMP,
-        Ogre::TextureUnitState::TAM_CLAMP,
-        Ogre::TextureUnitState::TAM_CLAMP
-    };
-#endif //CEGUI_USE_OGRE_HLMS
-
-//----------------------------------------------------------------------------//
-#ifdef CEGUI_USE_OGRE_HLMS
-void OgreRenderer::initialiseRenderStateSettings(Ogre::RenderTarget* target)
-#else
-void OgreRenderer::initialiseRenderStateSettings()
-#endif
+void OgreRenderer::initialiseRenderStateSettings(Ogre::TextureGpu* target, Ogre::RenderPassDescriptor* ogreRenderPassDescriptor)
 {
-    using namespace Ogre;
-
-#ifdef CEGUI_USE_OGRE_HLMS
     // The geometry buffer is responsible for binding all our hlms blocks
     // when it is ready to render
 
     // But we need to prepare the PSO cache to generate PSOs for this render target
-
-    // This is in the Ogre example usage but doesn't seem to be needed.
-    // d_pimpl->d_hlmsCache->clearState();
-    d_pimpl->d_hlmsCache->setRenderTarget(target);
-
-#else
-    // initialise render settings
-    d_pimpl->d_renderSystem->setLightingEnabled(false);
-    d_pimpl->d_renderSystem->_setDepthBufferParams(false, false);
-    d_pimpl->d_renderSystem->_setDepthBias(0, 0);
-    d_pimpl->d_renderSystem->_setCullingMode(CULL_NONE);
-    d_pimpl->d_renderSystem->_setFog(FOG_NONE);
-    d_pimpl->d_renderSystem->_setColourBufferWriteEnabled(true, true, true, true);
-    d_pimpl->d_renderSystem->setShadingType(SO_GOURAUD);
-    d_pimpl->d_renderSystem->_setPolygonMode(PM_SOLID);
-    d_pimpl->d_renderSystem->setScissorTest(false);
-
-    // set alpha blending to known state
-    setupRenderingBlendMode(BlendMode::Normal, true);
-#endif //CEGUI_USE_OGRE_HLMS
-
+    d_pimpl->d_hlmsCache->setRenderTarget(ogreRenderPassDescriptor);
 }
 
 //----------------------------------------------------------------------------//
-void OgreRenderer::setDefaultRootRenderTarget(Ogre::RenderTarget& target)
+void OgreRenderer::setDefaultRootRenderTarget(Ogre::Window* target)
 {
     d_pimpl->d_defaultTarget->setOgreRenderTarget(target);
 }
 
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
-void OgreRenderer::updateWorkspaceRenderTarget(Ogre::RenderTarget& target)
+void OgreRenderer::updateWorkspaceRenderTarget(Ogre::TextureGpu* target)
 {
     // There seems to be no way to change the target, so we need to recreate it
     Ogre::CompositorManager2* manager = d_pimpl->d_ogreRoot->
@@ -1323,10 +1186,8 @@ void OgreRenderer::updateWorkspaceRenderTarget(Ogre::RenderTarget& target)
 
     // The -1 should guarantee this to be rendered last on top of everything
     d_pimpl->d_workspace = manager->addWorkspace(d_pimpl->d_dummyScene,
-        &target, d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
+        target, d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
 }
-#endif // CEGUI_USE_OGRE_COMPOSITOR2
-
 //----------------------------------------------------------------------------//
 void OgreRenderer::setViewProjectionMatrix(const glm::mat4& viewProjMatrix)
 {
@@ -1334,6 +1195,7 @@ void OgreRenderer::setViewProjectionMatrix(const glm::mat4& viewProjMatrix)
 
     d_viewProjectionMatrix = viewProjMatrix;
 
+#ifdef OGRE_ENABLE_INCOMPATIBLE
     if (d_pimpl->d_renderSystem->_getViewport()->getTarget()->requiresTextureFlipping())
     {
         d_viewProjectionMatrix[0][1] = -d_viewProjectionMatrix[0][1];
@@ -1341,6 +1203,7 @@ void OgreRenderer::setViewProjectionMatrix(const glm::mat4& viewProjMatrix)
         d_viewProjectionMatrix[2][1] = -d_viewProjectionMatrix[2][1];
         d_viewProjectionMatrix[3][1] = -d_viewProjectionMatrix[3][1];
     }
+#endif
 }
 
 //----------------------------------------------------------------------------//
@@ -1409,11 +1272,10 @@ GeometryBuffer& OgreRenderer::createGeometryBufferTextured(
 }
 
 //----------------------------------------------------------------------------//
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+
 Ogre::SceneManager& OgreRenderer::getDummyScene() const{
     return *d_pimpl->d_dummyScene;
 }
-#endif
 
 //----------------------------------------------------------------------------//
 UsedOgreHWBuffer OgreRenderer::getVertexBuffer(size_t
@@ -1490,7 +1352,7 @@ UsedOgreHWBuffer OgreRenderer::getVertexBuffer(size_t
     return result;
 }
 
-void OgreRenderer::returnVertexBuffer(UsedOgreHWBuffer
+void OgreRenderer::returnVertexBuffer(Ogre::v1::HardwareVertexBufferSharedPtr
     buffer)
 {
     d_pimpl->d_vbPool.push_back(buffer);
@@ -1532,22 +1394,12 @@ void OgreRenderer::cleanLargestVertexBufferPool(size_t count)
 //----------------------------------------------------------------------------//
 void OgreRenderer::initialiseTextureStates()
 {
-#ifndef CEGUI_USE_OGRE_HLMS
-    d_pimpl->d_renderSystem->_setTextureCoordCalculation(0, Ogre::TEXCALC_NONE);
-    d_pimpl->d_renderSystem->_setTextureCoordSet(0, 0);
-    d_pimpl->d_renderSystem->_setTextureAddressingMode(0, S_textureAddressMode);
-    d_pimpl->d_renderSystem->_setTextureMatrix(0, Ogre::Matrix4::IDENTITY);
-    d_pimpl->d_renderSystem->_setTextureUnitFiltering(0, Ogre::FO_LINEAR, Ogre::FO_LINEAR, Ogre::FO_NONE);
-    d_pimpl->d_renderSystem->_setAlphaRejectSettings(Ogre::CMPF_ALWAYS_PASS, 0, false);
-    d_pimpl->d_renderSystem->_setTextureBlendMode(0, S_colourBlendMode);
-    d_pimpl->d_renderSystem->_setTextureBlendMode(0, S_alphaBlendMode);
-
-#else
     d_pimpl->d_renderSystem->_setHlmsSamplerblock(0, d_pimpl->d_hlmsSamplerblock);
-#endif //CEGUI_USE_OGRE_HLMS
 
+#ifdef OGRE_ENABLE_INCOMPATIBLE
     // This might be a good setting in Ogre 2.1, too
     d_pimpl->d_renderSystem->_disableTextureUnitsFrom(1);
+#endif
 }
 
 //----------------------------------------------------------------------------//
@@ -1567,11 +1419,78 @@ bool OgreRenderer::isTexCoordSystemFlipped() const
 {
     return false;
 }
+//----------------------------------------------------------------------------//
+void OgreRenderer::drawManualGuiContext(CEGUI::GUIContext* guiContext)
+{
+	//render given guiContext, probalby to render a Cegui-RTT used on an OgreTextureGpu
+
+	if(!guiContext)
+		return;
+
+	//configure the RenderQueueListener:
+	d_pimpl->d_frameListener->mGUIContextToRender = guiContext;	//configure the FrameListener to render just that one guiContext
+
+	//Manual Render workspace:
+	{	
+		d_pimpl->d_dummyScene->updateSceneGraph();		
+		d_pimpl->d_workspace->_beginUpdate(true);
+		d_pimpl->d_workspace->_update();
+		d_pimpl->d_workspace->_endUpdate(true);
+		Ogre::vector<Ogre::TextureGpu*>::type swappedTargets;
+		d_pimpl->d_workspace->_swapFinalTarget(swappedTargets);
+		d_pimpl->d_dummyScene->clearFrameData();
+	}
+
+	d_pimpl->d_frameListener->mGUIContextToRender = 0;
+}
+
+bool OgreRenderer::hasGuiContextToRenderEveryFrame(CEGUI::GUIContext* guiContext) const
+{
+	return (std::find(d_RenderingModeManual_GuiContextToRenderEveryFrame.begin(), d_RenderingModeManual_GuiContextToRenderEveryFrame.end(), guiContext) != d_RenderingModeManual_GuiContextToRenderEveryFrame.end());
+}
+
+void OgreRenderer::addGuiContextToRenderEveryFrame(CEGUI::GUIContext* guiContext)
+{
+	if(hasGuiContextToRenderEveryFrame(guiContext))
+		return;	//do not 
+	
+	d_RenderingModeManual_GuiContextToRenderEveryFrame.push_back(guiContext);
+}
+
+void OgreRenderer::removeGuiContextToRenderEveryFrame(CEGUI::GUIContext* guiContext)
+{
+	std::vector<CEGUI::GUIContext*>::iterator iter = std::find(d_RenderingModeManual_GuiContextToRenderEveryFrame.begin(), d_RenderingModeManual_GuiContextToRenderEveryFrame.end(), guiContext);
+	if(iter != d_RenderingModeManual_GuiContextToRenderEveryFrame.end())
+		d_RenderingModeManual_GuiContextToRenderEveryFrame.erase(iter);
+}
+
+void OgreRenderer::addGuiContextToRenderQueuedOnce(CEGUI::GUIContext* guiContext)
+{
+	//allow no duplicates
+	if(std::find(d_RenderingModeManual_GuiContextToRenderEveryFrame.begin(), d_RenderingModeManual_GuiContextToRenderEveryFrame.end(), guiContext) != d_RenderingModeManual_GuiContextToRenderEveryFrame.end())
+		return;
+
+	d_RenderingModeManual_GuiContextToRenderQueuedOnce.push_back(guiContext);
+}
+
+void OgreRenderer::clearGuiContextsToRenderQueuedOnce()
+{
+	d_RenderingModeManual_GuiContextToRenderQueuedOnce.clear();
+}
+
+const std::vector<CEGUI::GUIContext*>& OgreRenderer::getGuiContextsToRenderEveryFrame() const
+{
+	return d_RenderingModeManual_GuiContextToRenderEveryFrame;
+}
+
+const std::vector<CEGUI::GUIContext*>& OgreRenderer::getGuiContextsToRenderQueuedOnce() const
+{
+	return d_RenderingModeManual_GuiContextToRenderQueuedOnce;
+}
 
 //----------------------------------------------------------------------------//
-#ifdef CEGUI_USE_OGRE_COMPOSITOR2
 OgreGUIRenderQueueListener::OgreGUIRenderQueueListener(OgreRenderer* owner) :
-    d_enabled(true), d_owner(owner)
+    d_enabled(true), d_owner(owner), mGUIContextToRender(0)
 {
 
 }
@@ -1590,42 +1509,1666 @@ bool OgreGUIRenderQueueListener::isCEGUIRenderEnabled() const
 
 void OgreGUIRenderQueueListener::passPreExecute(Ogre::CompositorPass *pass)
 {
-
-    if (d_enabled && pass->getType() == Ogre::PASS_SCENE)
-    {
-        // We should only render contexts that are on this render target
-        System::getSingleton().renderAllGUIContextsOnTarget(d_owner);
-    }
+	if(pass->getType() == Ogre::PASS_SCENE)
+	{
+		if(mGUIContextToRender)
+		{
+			//render manually only the one GUIContext that is set
+			d_owner->beginRendering();
+			mGUIContextToRender->draw();
+			d_owner->endRendering();
+			// do final destruction on dead-pool windows
+			WindowManager::getSingleton().cleanDeadPool();
+		}
+		else if(d_owner->getRenderingMode() == OgreRenderer::RenderingMode_ConfigureManual)
+		{
+			const std::vector<CEGUI::GUIContext*>& guiContextToRenderEveryFrame = d_owner->getGuiContextsToRenderEveryFrame();
+			const std::vector<CEGUI::GUIContext*>& guiContextToRenderQueuedOnce = d_owner->getGuiContextsToRenderQueuedOnce();
+			if(guiContextToRenderEveryFrame.size() > 0 || guiContextToRenderQueuedOnce.size() > 0)
+			{
+				//render what is configured when running automatically
+				d_owner->beginRendering();
+				for(std::vector<CEGUI::GUIContext*>::const_iterator iter = guiContextToRenderEveryFrame.begin(); iter != guiContextToRenderEveryFrame.end(); ++iter)
+					(*iter)->draw();
+				for(std::vector<CEGUI::GUIContext*>::const_iterator iter = guiContextToRenderQueuedOnce.begin(); iter != guiContextToRenderQueuedOnce.end(); ++iter)
+					(*iter)->draw();
+				d_owner->endRendering();
+				// do final destruction on dead-pool windows
+				WindowManager::getSingleton().cleanDeadPool();		
+			}	
+			d_owner->clearGuiContextsToRenderQueuedOnce();
+		}
+		else if(d_owner->getRenderingMode() == OgreRenderer::RenderingMode_RenderAllCeguiGUIContexts)
+		{
+			//OgreProfile("CEGUI renderAllGUIContextsOnTarget");
+			// We should only render contexts that are on this render target
+			System::getSingleton().renderAllGUIContextsOnTarget(d_owner);
+		}
+	}
 }
 
 //----------------------------------------------------------------------------//
+} // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
+#include "CEGUI/RendererModules/Ogre/TextureTarget.h"
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/RendererModules/Ogre/WindowTarget.h"
+#include "CEGUI/GUIContext.h"
+#include "CEGUI/Exceptions.h"
+#include "CEGUI/System.h"
+#include "CEGUI/RendererModules/Ogre/ResourceProvider.h"
+#include "CEGUI/RendererModules/Ogre/ImageCodec.h"
+#include "CEGUI/Logger.h"
+
+#include <OgreRoot.h>
+#include <OgreRenderSystem.h>
+#include <OgreRenderWindow.h>
+#include <OgreHighLevelGpuProgramManager.h>
+#include <OgreHighLevelGpuProgram.h>
+#include <OgreGpuProgramManager.h>
+#include <OgreGpuProgramParams.h>
+#include <OgreFrameListener.h>
+#include <OgreViewport.h>
+#include <OgreCamera.h>
+#include <OgreHardwareVertexBuffer.h>
+
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+#include <Compositor/OgreCompositorManager2.h>
+#include <Compositor/OgreCompositorCommon.h>
+#include <Compositor/OgreCompositorWorkspaceDef.h>
+#include <Compositor/OgreCompositorWorkspace.h>
+#include <Compositor/OgreCompositorNodeDef.h>
+#include <Compositor/Pass/PassClear/OgreCompositorPassClear.h>
+#include <Compositor/Pass/PassScene/OgreCompositorPassScene.h>
+#include <Compositor/OgreCompositorWorkspaceListener.h>
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+
+#ifdef CEGUI_USE_OGRE_HLMS
+#include <OgreHlmsManager.h>
+#include <OgreHlmsDatablock.h>
+#include <OgrePsoCacheHelper.h>
+#include <OgreProfiler.h>
+#endif
+
+#ifndef CEGUI_USE_OGRE_HLMS
+#if OGRE_VERSION >= 0x10800
+#   include "OgreRTShaderConfig.h"
+#endif
+#endif
+
+#if OGRE_VERSION >= 0x020100
+#include <CommandBuffer/OgreCbDrawCall.h>
+#endif
+
+#include "CEGUI/RendererModules/Ogre/ShaderWrapper.h"
+
+#include "Shaders.inl"
+
+#include "glm/gtc/type_ptr.hpp"
+
+#include <unordered_map>
+
+#define VERTEXBUFFER_POOL_SIZE_STARTCLEAR           60
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+	//----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+// The new method will be used
+// Internal Ogre::CompositorWorkspaceListener. This is how the renderer gets notified
+// of workspaces that need rendering
+	class OgreGUIRenderQueueListener : public Ogre::CompositorWorkspaceListener
+	{
+	public:
+		OgreGUIRenderQueueListener(OgreRenderer* owner);
+
+		virtual ~OgreGUIRenderQueueListener() {}
+
+		void setCEGUIRenderEnabled(bool enabled);
+		bool isCEGUIRenderEnabled() const;
+
+		virtual void passPreExecute(Ogre::CompositorPass *pass);
+
+	private:
+		bool d_enabled;
+		OgreRenderer* d_owner;
+
+	};
+
+#else // Use the old method
+// Internal Ogre::FrameListener based class.  This is how we noew hook into the
+// rendering process (as opposed to render queues previously)
+	static class OgreGUIFrameListener : public Ogre::FrameListener
+	{
+	public:
+		OgreGUIFrameListener();
+
+		void setCEGUIRenderEnabled(bool enabled);
+		bool isCEGUIRenderEnabled() const;
+
+		bool frameRenderingQueued(const Ogre::FrameEvent& evt);
+
+	private:
+		bool d_enabled;
+
+	} S_frameListener;
+
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+	//----------------------------------------------------------------------------//
+	//! container type used to hold TextureTargets we create.
+	typedef std::vector<TextureTarget*> TextureTargetList;
+	//! container type used to hold GeometryBuffers we create.
+	typedef std::vector<OgreGeometryBuffer*> GeometryBufferList;
+	//! container type used to hold Textures we create.
+	typedef std::unordered_map<String, OgreTexture*> TextureMap;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+	typedef Ogre::v1::HardwareVertexBufferSharedPtr UsedOgreHWBuffer;
+#else
+	typedef Ogre::HardwareVertexBufferSharedPtr UsedOgreHWBuffer;
+#endif //CEGUI_USE_OGRE_HLMS
+
+	//----------------------------------------------------------------------------//
+	// Implementation data for the OgreRenderer
+	struct OgreRenderer_impl
+	{
+		OgreRenderer_impl() :
+			//! TODO: Currently there is no way to do this easily using Ogre
+			d_maxTextureSize(2048),
+			d_ogreRoot(Ogre::Root::getSingletonPtr()),
+#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
+			d_previousVP(0),
+#else
+			d_frameListener(0),
+			d_dummyScene(0),
+			d_dummyCamera(0),
+			d_workspace(0),
+#endif
+#ifdef CEGUI_USE_OGRE_HLMS
+			//d_renderTarget(nullptr),
+			d_hlmsMacroblock(nullptr),
+			d_hlmsBlendblock(nullptr),
+			d_hlmsSamplerblock(nullptr),
+#endif
+			d_activeBlendMode(BlendMode::Invalid),
+			d_makeFrameControlCalls(true),
+			d_useGLSL(false),
+			d_useGLSLES(false),
+			d_useHLSL(false),
+			d_useGLSLCore(false),
+			d_texturedShaderWrapper(0),
+			d_colouredShaderWrapper(0)
+		{}
+
+
+		//! String holding the renderer identification text.
+		static String d_rendererID;
+		//! What the renderer considers to be the current display size.
+		Sizef d_displaySize;
+		//! The default RenderTarget
+		OgreWindowTarget* d_defaultTarget;
+		//! Container used to track texture targets.
+		TextureTargetList d_textureTargets;
+		//! Container used to track geometry buffers.
+		GeometryBufferList d_geometryBuffers;
+		//! Container used to track textures.
+		TextureMap d_textures;
+		//! What the renderer thinks the max texture size is.
+		unsigned int d_maxTextureSize;
+		//! OGRE root object ptr
+		Ogre::Root* d_ogreRoot;
+		//! Pointer to the render system for Ogre.
+		Ogre::RenderSystem* d_renderSystem;
+#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
+		//! Pointer to the previous viewport set in render system.
+		Ogre::Viewport* d_previousVP;
+		//! Previous projection matrix set on render system.
+		Ogre::Matrix4 d_previousProjMatrix;
+#else
+
+		//! This is used to get notifications when our scene is rendered
+		//! no longer static because it requires a pointer to this
+		OgreGUIRenderQueueListener* d_frameListener;
+
+		//! Used to render at the correct time
+		Ogre::SceneManager* d_dummyScene;
+		//! This might not be needed, but it's here
+		Ogre::Camera* d_dummyCamera;
+
+		Ogre::CompositorWorkspace* d_workspace;
+
+		//! Makes all scene names unique
+		static int s_createdSceneNumber;
+
+		//! Allows the initialization to remain the same by automatically
+		//! initializing the Compositor if it isn't already
+		static bool s_compositorResourcesInitialized;
+
+#endif
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		//! OGRE render target
+		//Ogre::RenderTarget* d_renderTarget;
+		//! HLMS block used to set macro parameters
+		const Ogre::HlmsMacroblock* d_hlmsMacroblock;
+		//! HLMS block used to set blending parameters
+		const Ogre::HlmsBlendblock* d_hlmsBlendblock;
+		//! HLMS block used to set sampling parameters
+		const Ogre::HlmsSamplerblock* d_hlmsSamplerblock;
+
+		//! HLMS cache used to store pso
+		Ogre::SharedPtr<Ogre::PsoCacheHelper> d_hlmsCache;
+#endif
+
+		//! What we think is the current blend mode to use
+		BlendMode d_activeBlendMode;
+		//! Whether _beginFrame and _endFrame will be called.
+		bool d_makeFrameControlCalls;
+		//! Whether shaders are glsl or hlsl
+		bool d_useGLSL;
+		//! Whether shaders are glsles
+		bool d_useGLSLES;
+		//! Whether shaders are hlsl
+		bool d_useHLSL;
+		//! Whether we use the ARB glsl shaders or the OpenGL 3.2 Core shader profile (140 core)
+		bool d_useGLSLCore;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		//! Vector containing vertex buffers that can be reused
+		std::vector<Ogre::v1::HardwareVertexBufferSharedPtr> d_vbPool;
+#else
+		//! Vector containing vertex buffers that can be reused
+		std::vector<Ogre::HardwareVertexBufferSharedPtr> d_vbPool;
+#endif //CEGUI_USE_OGRE_HLMS
+
+		OgreShaderWrapper* d_texturedShaderWrapper;
+		OgreShaderWrapper* d_colouredShaderWrapper;
+	};
+
+	//----------------------------------------------------------------------------//
+	String OgreRenderer_impl::d_rendererID(
+		"CEGUI::OgreRenderer - OGRE based 3rd generation renderer module"
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		" with Ogre::Compositor2 enabled"
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+		".");
+
+#if defined(CEGUI_USE_OGRE_COMPOSITOR2)
+	int OgreRenderer_impl::s_createdSceneNumber = 0;
+	bool OgreRenderer_impl::s_compositorResourcesInitialized = false;
+#endif
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer& OgreRenderer::bootstrapSystem(const int abi)
+	{
+		System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
+
+		if(System::getSingletonPtr())
+			throw InvalidRequestException(
+				"CEGUI::System object is already initialised.");
+
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		createOgreCompositorResources();
+#endif
+
+		OgreRenderer& renderer = create();
+		OgreResourceProvider& rp = createOgreResourceProvider();
+		OgreImageCodec& ic = createOgreImageCodec();
+		System::create(renderer, &rp, static_cast<XMLParser*>(0), &ic);
+
+		return renderer;
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer& OgreRenderer::bootstrapSystem(Ogre::RenderTarget& target,
+		const int abi)
+	{
+		System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
+
+		if(System::getSingletonPtr())
+			throw InvalidRequestException(
+				"CEGUI::System object is already initialised.");
+
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		createOgreCompositorResources();
+#endif
+
+		OgreRenderer& renderer = OgreRenderer::create(target);
+		OgreResourceProvider& rp = createOgreResourceProvider();
+		OgreImageCodec& ic = createOgreImageCodec();
+		System::create(renderer, &rp, static_cast<XMLParser*>(0), &ic);
+
+		return renderer;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroySystem()
+	{
+		System* sys;
+		if(!(sys = System::getSingletonPtr()))
+			throw InvalidRequestException(
+				"CEGUI::System object is not created or was already destroyed.");
+
+		OgreRenderer* renderer = static_cast<OgreRenderer*>(sys->getRenderer());
+		OgreResourceProvider* rp =
+			static_cast<OgreResourceProvider*>(sys->getResourceProvider());
+
+		OgreImageCodec* ic = &static_cast<OgreImageCodec&>(sys->getImageCodec());
+
+		System::destroy();
+		destroyOgreImageCodec(*ic);
+		destroyOgreResourceProvider(*rp);
+		destroy(*renderer);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer& OgreRenderer::create(const int abi)
+	{
+		System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
+
+		return *new OgreRenderer();
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer& OgreRenderer::create(Ogre::RenderTarget& target,
+		const int abi)
+	{
+		System::performVersionTest(CEGUI_VERSION_ABI, abi, CEGUI_FUNCTION_NAME);
+
+		return *new OgreRenderer(target);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroy(OgreRenderer& renderer)
+	{
+		delete &renderer;
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreResourceProvider& OgreRenderer::createOgreResourceProvider()
+	{
+		return *new OgreResourceProvider();
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer& OgreRenderer::registerWindow(OgreRenderer& /*main_window*/,
+		Ogre::RenderTarget &new_window)
+	{
+		// Link the second renderer to the first for them to share some resources
+
+		return *new OgreRenderer(new_window);
+	}
+
+	//----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+	void OgreRenderer::createOgreCompositorResources()
+	{
+		// Create all the definitions for the workspaces and nodes
+
+		Ogre::CompositorManager2* manager = Ogre::Root::getSingleton().
+			getCompositorManager2();
+
+		// We want this to fail if it isn't initialized
+		if(!manager)
+			throw RendererException(
+				"Ogre CompositorManager2 is not initialized, "
+				"you must call Ogre::Root::initialiseCompositor() after "
+				"creating at least one window.");
+
+		Ogre::CompositorWorkspaceDef* templatedworkspace =
+			manager->addWorkspaceDefinition("CEGUI_workspace");
+
+		// Create a node for rendering on top of everything
+		Ogre::CompositorNodeDef* rendernode =
+			manager->addNodeDefinition("CEGUIRenderNode");
+
+		// Use the render target passed from the workspace for rendering on top of
+		// everything
+		rendernode->addTextureSourceName("renderwindow", 0,
+			Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+
+		rendernode->setNumTargetPass(1);
+
+		// Pass for it
+		Ogre::CompositorTargetDef* targetpasses =
+			rendernode->addTargetPass("renderwindow");
+		targetpasses->setNumPasses(2);
+
+		Ogre::CompositorPassClearDef* clearpass =
+			static_cast<Ogre::CompositorPassClearDef*>(targetpasses->
+				addPass(Ogre::PASS_CLEAR));
+
+
+
+		// Only clear depth and stencil since we are rendering on top
+		// of an existing image
+		clearpass->mClearBufferFlags = Ogre::FBT_DEPTH | Ogre::FBT_STENCIL;
+
+		// Now the render scene pass during which the render queue listener
+		// should render the GUI
+		Ogre::CompositorPassSceneDef* scenepass =
+			static_cast<Ogre::CompositorPassSceneDef*>(targetpasses->
+				addPass(Ogre::PASS_SCENE));
+#ifdef CEGUI_USE_OGRE_HLMS
+		(void)scenepass;
+
+#if(OGRE_PROFILING == OGRE_PROFILING_INTERNAL)
+		clearpass->mProfilingId = "CLEAR_CEGUI";
+		scenepass->mProfilingId = "SCENE_CEGUI";
+#endif
+
+		// Connect the main render target to the node
+		templatedworkspace->connectExternal(0, "CEGUIRenderNode", 0);
 
 #else
-OgreGUIFrameListener::OgreGUIFrameListener() :
-    d_enabled(true)
-{
-}
+		// Just render the overlay group since it is the only one used
+		scenepass->mFirstRQ = Ogre::RENDER_QUEUE_OVERLAY;
+		scenepass->mLastRQ = Ogre::RENDER_QUEUE_OVERLAY + 1;
 
-//----------------------------------------------------------------------------//
-void OgreGUIFrameListener::setCEGUIRenderEnabled(bool enabled)
-{
-    d_enabled = enabled;
-}
+		// Connect the main render target to the node
+		templatedworkspace->connectOutput("CEGUIRenderNode", 0);
+#endif //CEGUI_USE_OGRE_HLMS
 
-//----------------------------------------------------------------------------//
-bool OgreGUIFrameListener::isCEGUIRenderEnabled() const
-{
-    return d_enabled;
-}
+		// Resources now created
+		OgreRenderer_impl::s_compositorResourcesInitialized = true;
 
-//----------------------------------------------------------------------------//
-bool OgreGUIFrameListener::frameRenderingQueued(const Ogre::FrameEvent&)
-{
-    if (d_enabled)
-        System::getSingleton().renderAllGUIContexts();
+	}
+#endif
 
-    return true;
-}
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyOgreResourceProvider(OgreResourceProvider& rp)
+	{
+		delete &rp;
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreImageCodec& OgreRenderer::createOgreImageCodec()
+	{
+		return *new OgreImageCodec();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyOgreImageCodec(OgreImageCodec& ic)
+	{
+		delete &ic;
+	}
+
+	//----------------------------------------------------------------------------//
+	//! Conversion function from Ogre to glm
+	glm::mat4 OgreRenderer::ogreToGlmMatrix(const Ogre::Matrix4& matrix)
+	{
+		return glm::mat4(matrix[0][0], matrix[0][1], matrix[0][2], matrix[0][3],
+			matrix[1][0], matrix[1][1], matrix[1][2], matrix[1][3],
+			matrix[2][0], matrix[2][1], matrix[2][2], matrix[2][3],
+			matrix[3][0], matrix[3][1], matrix[3][2], matrix[3][3]);
+	}
+
+	//----------------------------------------------------------------------------//
+	//! Conversion function from glm to Ogre
+	Ogre::Matrix4 OgreRenderer::glmToOgreMatrix(const glm::mat4& matrix)
+	{
+		return Ogre::Matrix4(matrix[0][0], matrix[0][1], matrix[0][2], matrix[0][3],
+			matrix[1][0], matrix[1][1], matrix[1][2], matrix[1][3],
+			matrix[2][0], matrix[2][1], matrix[2][2], matrix[2][3],
+			matrix[3][0], matrix[3][1], matrix[3][2], matrix[3][3]);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setRenderingEnabled(const bool enabled)
+	{
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		d_pimpl->d_frameListener->setCEGUIRenderEnabled(enabled);
+		d_pimpl->d_workspace->setEnabled(false);
+#else
+		S_frameListener.setCEGUIRenderEnabled(enabled);
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::isRenderingEnabled() const
+	{
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		return d_pimpl->d_frameListener->isCEGUIRenderEnabled();
+#else
+		return S_frameListener.isCEGUIRenderEnabled();
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+	}
+
+	//----------------------------------------------------------------------------//
+	RenderTarget& OgreRenderer::getDefaultRenderTarget()
+	{
+		return *d_pimpl->d_defaultTarget;
+	}
+
+	//----------------------------------------------------------------------------//
+	TextureTarget* OgreRenderer::createTextureTarget(bool addStencilBuffer)
+	{
+		TextureTarget* tt = new OgreTextureTarget(*this, *d_pimpl->d_renderSystem, addStencilBuffer);
+		d_pimpl->d_textureTargets.push_back(tt);
+		return tt;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyTextureTarget(TextureTarget* target)
+	{
+		TextureTargetList::iterator i = std::find(d_pimpl->d_textureTargets.begin(),
+			d_pimpl->d_textureTargets.end(),
+			target);
+
+		if(d_pimpl->d_textureTargets.end() != i)
+		{
+			d_pimpl->d_textureTargets.erase(i);
+			delete target;
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyAllTextureTargets()
+	{
+		while(!d_pimpl->d_textureTargets.empty())
+			destroyTextureTarget(*d_pimpl->d_textureTargets.begin());
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreRenderer::createTexture(const String& name)
+	{
+		throwIfNameExists(name);
+
+		OgreTexture* t = new OgreTexture(name);
+		d_pimpl->d_textures[name] = t;
+
+		logTextureCreation(name);
+
+		return *t;
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreRenderer::createTexture(const String& name, const String& filename,
+		const String& resourceGroup)
+	{
+		throwIfNameExists(name);
+
+		OgreTexture* t = new OgreTexture(name, filename, resourceGroup);
+		d_pimpl->d_textures[name] = t;
+
+		logTextureCreation(name);
+
+		return *t;
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreRenderer::createTexture(const String& name, const Sizef& size)
+	{
+		throwIfNameExists(name);
+
+		OgreTexture* t = new OgreTexture(name, size);
+		d_pimpl->d_textures[name] = t;
+
+		logTextureCreation(name);
+
+		return *t;
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreRenderer::createTexture(const String& name, Ogre::TexturePtr& tex,
+		bool take_ownership)
+	{
+		throwIfNameExists(name);
+
+		OgreTexture* t = new OgreTexture(name, tex, take_ownership);
+		d_pimpl->d_textures[name] = t;
+
+		logTextureCreation(name);
+
+		return *t;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::throwIfNameExists(const String& name) const
+	{
+		if(d_pimpl->d_textures.find(name) != d_pimpl->d_textures.end())
+			throw AlreadyExistsException(
+				"[OgreRenderer] Texture already exists: " + name);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::logTextureCreation(const String& name)
+	{
+		Logger* logger = Logger::getSingletonPtr();
+		if(logger)
+			logger->logEvent("[OgreRenderer] Created texture: " + name);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyTexture(Texture& texture)
+	{
+		destroyTexture(texture.getName());
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyTexture(const String& name)
+	{
+		TextureMap::iterator i = d_pimpl->d_textures.find(name);
+
+		if(d_pimpl->d_textures.end() != i)
+		{
+			logTextureDestruction(name);
+			delete i->second;
+			d_pimpl->d_textures.erase(i);
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::logTextureDestruction(const String& name)
+	{
+		Logger* logger = Logger::getSingletonPtr();
+		if(logger)
+			logger->logEvent("[OgreRenderer] Destroyed texture: " + name);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::destroyAllTextures()
+	{
+		while(!d_pimpl->d_textures.empty())
+			destroyTexture(d_pimpl->d_textures.begin()->first);
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreRenderer::getTexture(const String& name) const
+	{
+		TextureMap::const_iterator i = d_pimpl->d_textures.find(name);
+
+		if(i == d_pimpl->d_textures.end())
+			throw UnknownObjectException("Texture does not exist: " + name);
+
+		return *i->second;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::isTextureDefined(const String& name) const
+	{
+		return d_pimpl->d_textures.find(name) != d_pimpl->d_textures.end();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::beginRendering()
+	{
+#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
+		if(!d_pimpl->d_previousVP)
+		{
+			d_pimpl->d_previousVP = d_pimpl->d_renderSystem->_getViewport();
+			if(d_pimpl->d_previousVP && d_pimpl->d_previousVP->getCamera())
+				d_pimpl->d_previousProjMatrix =
+				d_pimpl->d_previousVP->getCamera()->getProjectionMatrixRS();
+		}
+#endif
+
+		if(d_pimpl->d_makeFrameControlCalls)
+			d_pimpl->d_renderSystem->_beginFrame();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::endRendering()
+	{
+		if(d_pimpl->d_makeFrameControlCalls)
+			d_pimpl->d_renderSystem->_endFrame();
+
+#if !defined(CEGUI_USE_OGRE_COMPOSITOR2)
+		if(d_pimpl->d_previousVP)
+		{
+			d_pimpl->d_renderSystem->_setViewport(d_pimpl->d_previousVP);
+
+			if(d_pimpl->d_previousVP->getCamera())
+			{
+				d_pimpl->d_renderSystem->_setProjectionMatrix(
+					d_pimpl->d_previousProjMatrix);
+				d_pimpl->d_renderSystem->_setViewMatrix(
+					d_pimpl->d_previousVP->getCamera()->getViewMatrix());
+			}
+			d_pimpl->d_previousVP = 0;
+			d_pimpl->d_previousProjMatrix = Ogre::Matrix4::IDENTITY;
+		}
+#endif
+	}
+
+	//----------------------------------------------------------------------------//
+	const Sizef& OgreRenderer::getDisplaySize() const
+	{
+		return d_pimpl->d_displaySize;
+	}
+	//----------------------------------------------------------------------------//
+	unsigned int OgreRenderer::getMaxTextureSize() const
+	{
+		return d_pimpl->d_maxTextureSize;
+	}
+
+	//----------------------------------------------------------------------------//
+	const String& OgreRenderer::getIdentifierString() const
+	{
+		return d_pimpl->d_rendererID;
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer::OgreRenderer() :
+		d_pimpl(new OgreRenderer_impl())
+	{
+		checkOgreInitialised();
+
+		// get auto created window
+		Ogre::RenderWindow* rwnd = d_pimpl->d_ogreRoot->getAutoCreatedWindow();
+		if(!rwnd)
+			throw RendererException(
+				"Ogre was not initialised to automatically create a window, you "
+				"should therefore be explicitly specifying a Ogre::RenderTarget in "
+				"the OgreRenderer::create function.");
+
+		constructor_impl(*rwnd);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer::OgreRenderer(Ogre::RenderTarget& target) :
+		d_pimpl(new OgreRenderer_impl())
+	{
+		checkOgreInitialised();
+
+		constructor_impl(target);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreRenderer::~OgreRenderer()
+	{
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		// Remove the listener and then delete the scene
+		d_pimpl->d_workspace->setListener(0);
+
+		d_pimpl->d_ogreRoot->destroySceneManager(d_pimpl->d_dummyScene);
+
+		d_pimpl->d_dummyScene = 0;
+		d_pimpl->d_dummyCamera = 0;
+
+		// Remove the workspace so the contents aren't rendered anymore
+		d_pimpl->d_ogreRoot->getCompositorManager2()->removeWorkspace(
+			d_pimpl->d_workspace);
+
+		d_pimpl->d_workspace = 0;
+
+#else
+		d_pimpl->d_ogreRoot->removeFrameListener(&S_frameListener);
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+
+		cleanupShaders();
+
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+		delete d_pimpl->d_frameListener;
+#endif
+
+		destroyAllGeometryBuffers();
+		destroyAllTextureTargets();
+		destroyAllTextures();
+		clearVertexBufferPool();
+
+		delete d_pimpl->d_defaultTarget;
+		delete d_pimpl;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::checkOgreInitialised()
+	{
+		if(!d_pimpl->d_ogreRoot)
+			throw RendererException("The Ogre::Root object has not been "
+				"created. You must initialise Ogre first!");
+
+		if(!d_pimpl->d_ogreRoot->isInitialised())
+			throw RendererException("Ogre has not been initialised. You must "
+				"initialise Ogre first!");
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::constructor_impl(Ogre::RenderTarget& target)
+	{
+		d_pimpl->d_renderSystem = d_pimpl->d_ogreRoot->getRenderSystem();
+
+		d_pimpl->d_displaySize.d_width = static_cast<float>(target.getWidth());
+		d_pimpl->d_displaySize.d_height = static_cast<float>(target.getHeight());
+
+		//! Checking if OpenGL > 3.2 supported
+		if(d_pimpl->d_renderSystem->getName().find("OpenGL 3+") != Ogre::String::npos)
+		{
+			d_pimpl->d_useGLSLCore = true;
+		}
+
+		// create default target & rendering root (surface) that uses it
+		d_pimpl->d_defaultTarget =
+			new OgreWindowTarget(*this, *d_pimpl->d_renderSystem, target);
+
+#ifndef CEGUI_USE_OGRE_HLMS
+#if OGRE_VERSION >= 0x10800
+#ifndef RTSHADER_SYSTEM_BUILD_CORE_SHADERS
+		throw RendererException("RT Shader System not available. However CEGUI relies on shaders for rendering. ");
+#endif
+#endif
+#endif //CEGUI_USE_OGRE_HLMS
+
+		// hook into the rendering process
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+
+	// Some automatic bootstrapping
+		if(!OgreRenderer_impl::s_compositorResourcesInitialized)
+		{
+			createOgreCompositorResources();
+		}
+
+		// Create the dummy scene and camera
+		std::stringstream scene_name;
+		scene_name << "CEGUI_forWindow_" <<
+			OgreRenderer_impl::s_createdSceneNumber++;
+
+		d_pimpl->d_dummyScene = d_pimpl->d_ogreRoot->createSceneManager(
+			Ogre::ST_INTERIOR, 1, Ogre::INSTANCING_CULLING_SINGLETHREAD,
+			scene_name.str());
+
+		// Unused camera for the scene
+		d_pimpl->d_dummyCamera = d_pimpl->d_dummyScene->createCamera(
+			"CEGUI_dummy_camera");
+
+
+		// We will get notified when the workspace is drawn
+		d_pimpl->d_frameListener = new OgreGUIRenderQueueListener(this);
+
+		// Create the workspace for rendering
+		Ogre::CompositorManager2* manager = d_pimpl->d_ogreRoot->
+			getCompositorManager2();
+
+		// The -1 should guarantee this to be rendered last on top of everything
+		d_pimpl->d_workspace = manager->addWorkspace(d_pimpl->d_dummyScene,
+			&target, d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
+
+		d_pimpl->d_workspace->setListener(d_pimpl->d_frameListener);
+
+#else
+		d_pimpl->d_ogreRoot->addFrameListener(&S_frameListener);
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+
+		initialiseShaders();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::initialiseShaders()
+	{
+#ifdef CEGUI_USE_OGRE_HLMS
+		Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
+
+		// Macro block
+		Ogre::HlmsMacroblock macroblock;
+		macroblock.mDepthCheck = false;
+		macroblock.mDepthWrite = false;
+		macroblock.mDepthBiasConstant = 0;
+		macroblock.mDepthBiasSlopeScale = 0;
+		macroblock.mCullMode = Ogre::CULL_NONE;
+		macroblock.mPolygonMode = Ogre::PM_SOLID;
+		macroblock.mScissorTestEnabled = true;
+		d_pimpl->d_hlmsMacroblock = hlmsManager->getMacroblock(macroblock);
+
+		// Sampler block
+		Ogre::HlmsSamplerblock samplerblock;
+		samplerblock.mMinFilter = Ogre::FO_LINEAR;
+		samplerblock.mMagFilter = Ogre::FO_LINEAR;
+		samplerblock.mMipFilter = Ogre::FO_POINT;
+		samplerblock.mU = Ogre::TAM_CLAMP;
+		samplerblock.mV = Ogre::TAM_CLAMP;
+		samplerblock.mW = Ogre::TAM_CLAMP;
+		samplerblock.mCompareFunction = Ogre::NUM_COMPARE_FUNCTIONS;
+		d_pimpl->d_hlmsSamplerblock = hlmsManager->getSamplerblock(samplerblock);
+
+		// PSO
+		d_pimpl->d_hlmsCache = Ogre::SharedPtr<Ogre::PsoCacheHelper>(
+			new Ogre::PsoCacheHelper(d_pimpl->d_renderSystem));
+
+#endif
+
+		Ogre::HighLevelGpuProgramPtr texture_vs;
+		Ogre::HighLevelGpuProgramPtr texture_ps;
+
+		Ogre::HighLevelGpuProgramPtr colour_vs;
+		Ogre::HighLevelGpuProgramPtr colour_ps;
+
+		d_pimpl->d_useGLSL = Ogre::HighLevelGpuProgramManager::getSingleton().
+			isLanguageSupported("glsl");
+		d_pimpl->d_useGLSLES = Ogre::HighLevelGpuProgramManager::getSingleton().
+			isLanguageSupported("glsles");
+		d_pimpl->d_useHLSL = Ogre::HighLevelGpuProgramManager::getSingleton().
+			isLanguageSupported("hlsl");
+
+		Ogre::String shaderLanguage;
+
+		if(d_pimpl->d_useGLSL)
+		{
+			shaderLanguage = "glsl";
+		}
+		else if(d_pimpl->d_useGLSLES)
+		{
+			shaderLanguage = "glsles";
+		}
+		else if(d_pimpl->d_useHLSL)
+		{
+			shaderLanguage = "hlsl";
+		}
+		else {
+			throw RendererException("Underlying Ogre render system does not support available "
+				"shader languages which should be one of glsl, glsles or hlsl "
+				"which are required for supporting custom shaders in this CEGUI version");
+		}
+
+		// Create vertex shaders
+		texture_vs = Ogre::HighLevelGpuProgramManager::getSingleton().
+			createProgram("__cegui_internal_texture_vs__",
+				Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+				shaderLanguage, Ogre::GPT_VERTEX_PROGRAM);
+
+		colour_vs = Ogre::HighLevelGpuProgramManager::getSingleton().
+			createProgram("__cegui_internal_colour_vs__",
+				Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+				shaderLanguage, Ogre::GPT_VERTEX_PROGRAM);
+
+		// Create pixel shaders
+		texture_ps = Ogre::HighLevelGpuProgramManager::getSingleton().
+			createProgram("__cegui_internal_texture_ps__",
+				Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+				shaderLanguage, Ogre::GPT_FRAGMENT_PROGRAM);
+
+		colour_ps = Ogre::HighLevelGpuProgramManager::getSingleton().
+			createProgram("__cegui_internal_colour_ps__",
+				Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+				shaderLanguage, Ogre::GPT_FRAGMENT_PROGRAM);
+
+		// We always enter through the main function
+		texture_vs->setParameter("entry_point", "main");
+		texture_ps->setParameter("entry_point", "main");
+		colour_vs->setParameter("entry_point", "main");
+		colour_ps->setParameter("entry_point", "main");
+
+		// If we use GLSL
+		if(d_pimpl->d_useGLSL)
+		{
+			// We check if we want to use a GLSL core shader, which is required for the Ogre OpenGL 3+ Renderer
+			if(d_pimpl->d_useGLSLCore)
+			{
+				texture_vs->setParameter("target", "glsl");
+				texture_vs->setSource(VertexShaderTextured_GLSL);
+
+				colour_vs->setParameter("target", "glsl");
+				colour_vs->setSource(VertexShaderColoured_GLSL);
+
+				texture_ps->setParameter("target", "glsl");
+				texture_ps->setSource(PixelShaderTextured_GLSL);
+
+				colour_ps->setParameter("target", "glsl");
+				colour_ps->setSource(PixelShaderColoured_GLSL);
+			}
+			else // else we use regular GLSL shader, as in the normal Ogre OpenGL Renderer
+			{
+				texture_vs->setParameter("target", "arbvp1");
+				texture_vs->setSource(VertexShaderTextured_GLSL_Compat);
+
+				colour_vs->setParameter("target", "arbvp1");
+				colour_vs->setSource(VertexShaderColoured_GLSL_Compat);
+
+				texture_ps->setParameter("target", "arbfp1");
+				texture_ps->setSource(PixelShaderTextured_GLSL_Compat);
+
+				colour_ps->setParameter("target", "arbfp1");
+				colour_ps->setSource(PixelShaderColoured_GLSL_Compat);
+			}
+		}
+		else if(d_pimpl->d_useGLSLES)
+		{
+			texture_vs->setParameter("target", "glsles");
+			texture_vs->setSource(VertexShaderTextured_GLSLES1);
+
+			colour_vs->setParameter("target", "glsles");
+			colour_vs->setSource(VertexShaderColoured_GLSLES1);
+
+			texture_ps->setParameter("target", "glsles");
+			texture_ps->setSource(PixelShaderTextured_GLSLES1);
+
+			colour_ps->setParameter("target", "glsles");
+			colour_ps->setSource(PixelShaderColoured_GLSLES1);
+		}
+		else // else we use a hlsl shader with an available syntax code
+		{
+			if(Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("vs_5_0"))
+			{
+				texture_vs->setParameter("target", "vs_5_0");
+				texture_vs->setSource(VertexShaderTextured_HLSL);
+
+				colour_vs->setParameter("target", "vs_5_0");
+				colour_vs->setSource(VertexShaderColoured_HLSL);
+			}
+			else if(Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("vs_4_0"))
+			{
+				texture_vs->setParameter("target", "vs_4_0");
+				texture_vs->setSource(VertexShaderTextured_HLSL);
+
+				colour_vs->setParameter("target", "vs_4_0");
+				colour_vs->setSource(VertexShaderColoured_HLSL);
+			}
+			else if(Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("vs_2_0"))
+			{
+				texture_vs->setParameter("target", "vs_2_0");
+				texture_vs->setSource(VertexShaderTextured_HLSL);
+
+				colour_vs->setParameter("target", "vs_2_0");
+				colour_vs->setSource(VertexShaderColoured_HLSL);
+			}
+			else// If no shader was compatible
+			{
+				throw RendererException(
+					"OgreRenderer::initialiseShaders: No supported syntax - "
+					"unable to compile for vs_5_0, vs_4_0 or vs_2_0");
+			}
+
+			if(Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("ps_5_0"))
+			{
+				texture_ps->setParameter("target", "ps_5_0");
+				texture_ps->setSource(PixelShaderTextured_PS5_HLSL);
+
+				colour_ps->setParameter("target", "ps_5_0");
+				colour_ps->setSource(PixelShaderColoured_PS5_HLSL);
+			}
+			else if(Ogre::GpuProgramManager::getSingletonPtr()->isSyntaxSupported("ps_4_0"))
+			{
+				texture_ps->setParameter("target", "ps_4_0");
+				texture_ps->setSource(PixelShaderTextured_PS5_HLSL);
+
+				colour_ps->setParameter("target", "ps_4_0");
+				colour_ps->setSource(PixelShaderColoured_PS5_HLSL);
+			}
+			else if(Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("ps_2_0"))
+			{
+				texture_ps->setParameter("target", "ps_2_0");
+				texture_ps->setSource(PixelShaderTextured_HLSL);
+
+				colour_ps->setParameter("target", "ps_2_0");
+				colour_ps->setSource(PixelShaderColoured_HLSL);
+			}
+			else
+			{
+				throw RendererException(
+					"OgreRenderer::initialiseShaders: No supported syntax - "
+					"unable to compile for ps_5_0, ps_4_0 or ps_2_0");
+			}
+
+		}
+
+		// Load all the shaders after setting the source code
+		texture_vs->load();
+		texture_ps->load();
+		colour_vs->load();
+		colour_ps->load();
+
+		d_pimpl->d_texturedShaderWrapper = new OgreShaderWrapper(*this,
+			*d_pimpl->d_renderSystem, texture_vs, texture_ps);
+
+		d_pimpl->d_colouredShaderWrapper = new OgreShaderWrapper(*this,
+			*d_pimpl->d_renderSystem, colour_vs, colour_ps);
+	}
+
+	void OgreRenderer::cleanupShaders()
+	{
+		delete d_pimpl->d_texturedShaderWrapper;
+		delete d_pimpl->d_colouredShaderWrapper;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+
+		Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
+
+		d_pimpl->d_hlmsCache.setNull();
+
+		if(d_pimpl->d_hlmsBlendblock != nullptr)
+			hlmsManager->destroyBlendblock(d_pimpl->d_hlmsBlendblock);
+		if(d_pimpl->d_hlmsMacroblock != nullptr)
+			hlmsManager->destroyMacroblock(d_pimpl->d_hlmsMacroblock);
+		if(d_pimpl->d_hlmsSamplerblock != nullptr)
+			hlmsManager->destroySamplerblock(d_pimpl->d_hlmsSamplerblock);
+
+
+
+#endif //CEGUI_USE_OGRE_HLMS
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setDisplaySize(const Sizef& sz)
+	{
+		if(sz != d_pimpl->d_displaySize)
+		{
+			d_pimpl->d_displaySize = sz;
+
+			// FIXME: This is probably not the right thing to do in all cases.
+			Rectf area(d_pimpl->d_defaultTarget->getArea());
+			area.setSize(sz);
+			d_pimpl->d_defaultTarget->setArea(area);
+		}
+
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setupRenderingBlendMode(const BlendMode mode,
+		bool force)
+	{
+#ifdef CEGUI_USE_OGRE_HLMS
+		// Enable force if no blend block has been created
+		if(!d_pimpl->d_hlmsBlendblock)
+			force = true;
+
+#endif //CEGUI_USE_OGRE_HLMS
+
+		// do nothing if mode appears current (and is not forced)
+		if((d_pimpl->d_activeBlendMode == mode) && !force)
+			return;
+
+		d_pimpl->d_activeBlendMode = mode;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+
+		Ogre::HlmsManager* hlmsManager = d_pimpl->d_ogreRoot->getHlmsManager();
+
+		// Blend block
+		Ogre::HlmsBlendblock blendblock;
+		blendblock.mAlphaToCoverageEnabled = false;
+		if(d_pimpl->d_activeBlendMode == BlendMode::RttPremultiplied)
+		{
+			blendblock.mSourceBlendFactor = Ogre::SBF_SOURCE_ALPHA;
+			blendblock.mDestBlendFactor = Ogre::SBF_ONE_MINUS_SOURCE_ALPHA;
+		}
+		else
+		{
+			blendblock.mSeparateBlend = true;
+			blendblock.mSourceBlendFactor = Ogre::SBF_SOURCE_ALPHA;
+			blendblock.mDestBlendFactor = Ogre::SBF_ONE_MINUS_SOURCE_ALPHA;
+			blendblock.mSourceBlendFactorAlpha = Ogre::SBF_ONE_MINUS_DEST_ALPHA;
+			blendblock.mDestBlendFactorAlpha = Ogre::SBF_ONE;
+		}
+		d_pimpl->d_hlmsBlendblock = hlmsManager->getBlendblock(blendblock);
+
+
+#else
+		using namespace Ogre;
+
+		if(d_pimpl->d_activeBlendMode == BlendMode::RttPremultiplied)
+			d_pimpl->d_renderSystem->_setSceneBlending(SBF_ONE,
+				SBF_ONE_MINUS_SOURCE_ALPHA);
+		else
+			d_pimpl->d_renderSystem->
+			_setSeparateSceneBlending(SBF_SOURCE_ALPHA,
+				SBF_ONE_MINUS_SOURCE_ALPHA,
+				SBF_ONE_MINUS_DEST_ALPHA,
+				SBF_ONE);
+
+#endif //CEGUI_USE_OGRE_HLMS
+	}
+
+#ifdef CEGUI_USE_OGRE_HLMS
+	void OgreRenderer::bindPSO(const Ogre::v1::RenderOperation render_operation)
+	{
+		// Blendmode must be set before
+		assert(d_pimpl->d_hlmsBlendblock);
+
+		d_pimpl->d_hlmsCache->setBlendblock(const_cast<Ogre::HlmsBlendblock*>(
+			d_pimpl->d_hlmsBlendblock));
+		d_pimpl->d_hlmsCache->setMacroblock(const_cast<Ogre::HlmsMacroblock*>(
+			d_pimpl->d_hlmsMacroblock));
+
+#if OGRE_VERSION >= 0x020100
+		//! Needed for DX11 in order for InputLayout to be specified right when we get the PSO.
+		Ogre::VertexElement2VecVec elements = render_operation.vertexData->vertexDeclaration->convertToV2();
+		d_pimpl->d_hlmsCache->setVertexFormat(elements, render_operation.operationType, false);
+#endif
+
+		// This should have all the rendering settings
+		Ogre::HlmsPso* pso = d_pimpl->d_hlmsCache->getPso();
+		/*pso = 0;
+
+		{
+			const Ogre::uint32 renderableHash = d_pimpl->d_hlmsCache->getRenderableHash();
+			pso = d_pimpl->d_hlmsCache->getPso(renderableHash, true);
+		}*/
+
+		//Ogre::HlmsPso* pso = d_pimpl->d_hlmsCache->getPso((Ogre::uint32)0, true); //always request same Pso, otherwise Ogre2.1 will get out of control and create new Pso's over and other first causing slowdown and ultimatively application crash
+
+		// Bind it
+		d_pimpl->d_renderSystem->_setPipelineStateObject(pso);
+
+#if OGRE_VERSION >= 0x020100
+		const Ogre::v1::CbRenderOp cmd(render_operation);
+		d_pimpl->d_renderSystem->_setRenderOperation(&cmd);
+#endif
+	}
+
+	void OgreRenderer::setGPUPrograms(const Ogre::HighLevelGpuProgramPtr &vs,
+		const Ogre::HighLevelGpuProgramPtr &ps)
+	{
+		Ogre::GpuProgramPtr vsConverted = vs;
+		Ogre::GpuProgramPtr psConverted = ps;
+
+		d_pimpl->d_hlmsCache->setVertexShader(vsConverted);
+		d_pimpl->d_hlmsCache->setPixelShader(psConverted);
+	}
+
+#endif //CEGUI_USE_OGRE_HLMS
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setFrameControlExecutionEnabled(const bool enabled)
+	{
+		d_pimpl->d_makeFrameControlCalls = enabled;
+
+		// default rendering requires _beginFrame and _endFrame calls be made,
+		// so if we're disabling those we must also disable default rendering.
+		if(!d_pimpl->d_makeFrameControlCalls)
+			setRenderingEnabled(false);
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::isFrameControlExecutionEnabled() const
+	{
+		return d_pimpl->d_makeFrameControlCalls;
+	}
+
+	//----------------------------------------------------------------------------//
+	static const Ogre::LayerBlendModeEx S_colourBlendMode =
+	{
+		Ogre::LBT_COLOUR,
+		Ogre::LBX_MODULATE,
+		Ogre::LBS_TEXTURE,
+		Ogre::LBS_DIFFUSE,
+		Ogre::ColourValue(0, 0, 0, 0),
+		Ogre::ColourValue(0, 0, 0, 0),
+		0, 0, 0
+	};
+
+	//----------------------------------------------------------------------------//
+	static const Ogre::LayerBlendModeEx S_alphaBlendMode =
+	{
+		Ogre::LBT_ALPHA,
+		Ogre::LBX_MODULATE,
+		Ogre::LBS_TEXTURE,
+		Ogre::LBS_DIFFUSE,
+		Ogre::ColourValue(0, 0, 0, 0),
+		Ogre::ColourValue(0, 0, 0, 0),
+		0, 0, 0
+	};
+
+	//----------------------------------------------------------------------------//
+#ifndef CEGUI_USE_OGRE_HLMS
+	static const Ogre::TextureUnitState::UVWAddressingMode S_textureAddressMode =
+	{
+		Ogre::TextureUnitState::TAM_CLAMP,
+		Ogre::TextureUnitState::TAM_CLAMP,
+		Ogre::TextureUnitState::TAM_CLAMP
+	};
+#endif //CEGUI_USE_OGRE_HLMS
+
+	//----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_HLMS
+	void OgreRenderer::initialiseRenderStateSettings(Ogre::RenderTarget* target)
+#else
+	void OgreRenderer::initialiseRenderStateSettings()
+#endif
+	{
+		using namespace Ogre;
+
+#ifdef CEGUI_USE_OGRE_HLMS
+		// The geometry buffer is responsible for binding all our hlms blocks
+		// when it is ready to render
+
+		// But we need to prepare the PSO cache to generate PSOs for this render target
+		//d_pimpl->d_hlmsCache->clearState();
+		d_pimpl->d_hlmsCache->setRenderTarget(target);
+
+#else
+		// initialise render settings
+		d_pimpl->d_renderSystem->setLightingEnabled(false);
+		d_pimpl->d_renderSystem->_setDepthBufferParams(false, false);
+		d_pimpl->d_renderSystem->_setDepthBias(0, 0);
+		d_pimpl->d_renderSystem->_setCullingMode(CULL_NONE);
+		d_pimpl->d_renderSystem->_setFog(FOG_NONE);
+		d_pimpl->d_renderSystem->_setColourBufferWriteEnabled(true, true, true, true);
+		d_pimpl->d_renderSystem->setShadingType(SO_GOURAUD);
+		d_pimpl->d_renderSystem->_setPolygonMode(PM_SOLID);
+		d_pimpl->d_renderSystem->setScissorTest(false);
+
+		// set alpha blending to known state
+		setupRenderingBlendMode(BlendMode::Normal, true);
+#endif //CEGUI_USE_OGRE_HLMS
+
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setDefaultRootRenderTarget(Ogre::RenderTarget& target)
+	{
+		d_pimpl->d_defaultTarget->setOgreRenderTarget(target);
+	}
+
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+	void OgreRenderer::updateWorkspaceRenderTarget(Ogre::RenderTarget& target)
+	{
+		// There seems to be no way to change the target, so we need to recreate it
+		Ogre::CompositorManager2* manager = d_pimpl->d_ogreRoot->
+			getCompositorManager2();
+
+		d_pimpl->d_ogreRoot->getCompositorManager2()->removeWorkspace(
+			d_pimpl->d_workspace);
+
+		// The -1 should guarantee this to be rendered last on top of everything
+		d_pimpl->d_workspace = manager->addWorkspace(d_pimpl->d_dummyScene,
+			&target, d_pimpl->d_dummyCamera, "CEGUI_workspace", true, -1);
+	}
+#endif // CEGUI_USE_OGRE_COMPOSITOR2
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::setViewProjectionMatrix(const glm::mat4& viewProjMatrix)
+	{
+		d_pimpl->d_renderSystem->_setProjectionMatrix(OgreRenderer::glmToOgreMatrix(viewProjMatrix));
+
+		d_viewProjectionMatrix = viewProjMatrix;
+
+		if(d_pimpl->d_renderSystem->_getViewport()->getTarget()->requiresTextureFlipping())
+		{
+			d_viewProjectionMatrix[0][1] = -d_viewProjectionMatrix[0][1];
+			d_viewProjectionMatrix[1][1] = -d_viewProjectionMatrix[1][1];
+			d_viewProjectionMatrix[2][1] = -d_viewProjectionMatrix[2][1];
+			d_viewProjectionMatrix[3][1] = -d_viewProjectionMatrix[3][1];
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::bindBlendMode(BlendMode blend)
+	{
+		setupRenderingBlendMode(blend, false);
+	}
+
+	//----------------------------------------------------------------------------//
+	RefCounted<RenderMaterial> OgreRenderer::createRenderMaterial(
+		const DefaultShaderType shaderType) const
+	{
+		if(shaderType == DefaultShaderType::Textured)
+		{
+			RefCounted<RenderMaterial> render_material(new
+				RenderMaterial(d_pimpl->d_texturedShaderWrapper));
+
+			return render_material;
+		}
+		else if(shaderType == DefaultShaderType::Solid)
+		{
+			RefCounted<RenderMaterial> render_material(new
+				RenderMaterial(d_pimpl->d_colouredShaderWrapper));
+
+			return render_material;
+		}
+		else
+		{
+			throw RendererException("A default shader of this type does not exist.");
+
+			return RefCounted<RenderMaterial>();
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	GeometryBuffer& OgreRenderer::createGeometryBufferColoured(
+		CEGUI::RefCounted<RenderMaterial> renderMaterial)
+	{
+		OgreGeometryBuffer* geom_buffer = new OgreGeometryBuffer(*this,
+			*d_pimpl->d_renderSystem, renderMaterial);
+
+		geom_buffer->addVertexAttribute(VertexAttributeType::Position0);
+		geom_buffer->addVertexAttribute(VertexAttributeType::Colour0);
+		geom_buffer->finaliseVertexAttributes(
+			OgreGeometryBuffer::MT_COLOURED);
+
+		addGeometryBuffer(*geom_buffer);
+		return *geom_buffer;
+	}
+
+	//----------------------------------------------------------------------------//
+	GeometryBuffer& OgreRenderer::createGeometryBufferTextured(
+		CEGUI::RefCounted<RenderMaterial> renderMaterial)
+	{
+		OgreGeometryBuffer* geom_buffer = new OgreGeometryBuffer(*this,
+			*d_pimpl->d_renderSystem, renderMaterial);
+
+		geom_buffer->addVertexAttribute(VertexAttributeType::Position0);
+		geom_buffer->addVertexAttribute(VertexAttributeType::Colour0);
+		geom_buffer->addVertexAttribute(VertexAttributeType::TexCoord0);
+		geom_buffer->finaliseVertexAttributes(
+			OgreGeometryBuffer::MT_TEXTURED);
+
+		addGeometryBuffer(*geom_buffer);
+		return *geom_buffer;
+	}
+
+	//----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+	Ogre::SceneManager& OgreRenderer::getDummyScene() const {
+		return *d_pimpl->d_dummyScene;
+	}
+#endif
+
+	//----------------------------------------------------------------------------//
+	UsedOgreHWBuffer OgreRenderer::getVertexBuffer(size_t
+		min_size)
+	{
+		UsedOgreHWBuffer result(0);
+
+		if(d_pimpl->d_vbPool.empty())
+			return result;
+
+		size_t best_found = -1;
+		size_t best_over = -1;
+
+		// The vector is searched in reverse to find exact matches from the end
+		// which will allow popping the last element which is faster then removing
+		// the first one
+
+		for(size_t i = d_pimpl->d_vbPool.size(); --i > 0;)
+		{
+			// It seems that there can be nullptrs in the pool
+			UsedOgreHWBuffer current = d_pimpl->d_vbPool[i];
+
+			if(!current.get()) {
+
+				d_pimpl->d_vbPool.erase(d_pimpl->d_vbPool.begin() + i);
+				continue;
+			}
+
+			size_t current_over = current->getNumVertices() - min_size;
+
+			// Perfect match stops searching instantly
+			if(current_over == 0)
+			{
+
+				best_found = i;
+				best_over = 0;
+				break;
+			}
+
+			if(current_over <= best_over)
+			{
+
+				best_over = current_over;
+				best_found = i;
+			}
+		}
+
+		// If the smallest buffer is too large then none is found
+		// This will also be true if all buffers are too small
+		if(best_over > min_size*1.5f || best_found >= d_pimpl->d_vbPool.size())
+		{
+			// Clear if there are too many buffers
+			int over_size = d_pimpl->d_vbPool.size() -
+				VERTEXBUFFER_POOL_SIZE_STARTCLEAR;
+
+			if(over_size > 2)
+				cleanLargestVertexBufferPool(over_size);
+
+		}
+		else {
+
+			result = d_pimpl->d_vbPool[best_found];
+
+			d_pimpl->d_vbPool.erase(d_pimpl->d_vbPool.begin() + best_found);
+
+			// We want to avoid using too much memory
+			// even if matches are always found
+			int over_size = d_pimpl->d_vbPool.size() -
+				(VERTEXBUFFER_POOL_SIZE_STARTCLEAR * 5);
+
+			if(over_size > 5)
+				cleanLargestVertexBufferPool(over_size / 2);
+		}
+
+		return result;
+	}
+
+	void OgreRenderer::returnVertexBuffer(UsedOgreHWBuffer
+		buffer)
+	{
+		d_pimpl->d_vbPool.push_back(buffer);
+	}
+
+	void OgreRenderer::clearVertexBufferPool()
+	{
+		d_pimpl->d_vbPool.clear();
+	}
+
+	bool hardwareBufferSizeLess(const UsedOgreHWBuffer &first,
+		const UsedOgreHWBuffer &second)
+	{
+		return first->getNumVertices() < second->getNumVertices();
+	}
+
+	void OgreRenderer::cleanLargestVertexBufferPool(size_t count)
+	{
+		// The easiest way might be to sort the vector and delete the last count
+		// elements
+		std::sort(d_pimpl->d_vbPool.begin(), d_pimpl->d_vbPool.end(),
+			&hardwareBufferSizeLess);
+
+		// Adjust the count if there aren't enough elements to delete to avoid
+		// asserting
+		if(count >= d_pimpl->d_vbPool.size())
+		{
+
+			d_pimpl->d_vbPool.clear();
+		}
+
+		for(size_t i = 0; i < count; i++)
+		{
+
+			d_pimpl->d_vbPool.pop_back();
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreRenderer::initialiseTextureStates()
+	{
+#ifndef CEGUI_USE_OGRE_HLMS
+		d_pimpl->d_renderSystem->_setTextureCoordCalculation(0, Ogre::TEXCALC_NONE);
+		d_pimpl->d_renderSystem->_setTextureCoordSet(0, 0);
+		d_pimpl->d_renderSystem->_setTextureAddressingMode(0, S_textureAddressMode);
+		d_pimpl->d_renderSystem->_setTextureMatrix(0, Ogre::Matrix4::IDENTITY);
+		d_pimpl->d_renderSystem->_setTextureUnitFiltering(0, Ogre::FO_LINEAR, Ogre::FO_LINEAR, Ogre::FO_NONE);
+		d_pimpl->d_renderSystem->_setAlphaRejectSettings(Ogre::CMPF_ALWAYS_PASS, 0, false);
+		d_pimpl->d_renderSystem->_setTextureBlendMode(0, S_colourBlendMode);
+		d_pimpl->d_renderSystem->_setTextureBlendMode(0, S_alphaBlendMode);
+
+#else
+		d_pimpl->d_renderSystem->_setHlmsSamplerblock(0, d_pimpl->d_hlmsSamplerblock);
+#endif //CEGUI_USE_OGRE_HLMS
+
+		// This might be a good setting in Ogre 2.1, too
+		d_pimpl->d_renderSystem->_disableTextureUnitsFrom(1);
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::usesOpenGL()
+	{
+		return d_pimpl->d_renderSystem->getName().find("OpenGL") != Ogre::String::npos;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::usesDirect3D()
+	{
+		return d_pimpl->d_renderSystem->getName().find("Direct3D") != Ogre::String::npos;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreRenderer::isTexCoordSystemFlipped() const
+	{
+		return false;
+	}
+
+	//----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_COMPOSITOR2
+	OgreGUIRenderQueueListener::OgreGUIRenderQueueListener(OgreRenderer* owner) :
+		d_enabled(true), d_owner(owner)
+	{
+
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGUIRenderQueueListener::setCEGUIRenderEnabled(bool enabled)
+	{
+		d_enabled = enabled;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreGUIRenderQueueListener::isCEGUIRenderEnabled() const
+	{
+		return d_enabled;
+	}
+
+	void OgreGUIRenderQueueListener::passPreExecute(Ogre::CompositorPass *pass)
+	{
+
+		if(d_enabled && pass->getType() == Ogre::PASS_SCENE)
+		{
+			//OgreProfile("CEGUI renderAllGUIContextsOnTarget");
+			// We should only render contexts that are on this render target
+			System::getSingleton().renderAllGUIContextsOnTarget(d_owner);
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+
+#else
+	OgreGUIFrameListener::OgreGUIFrameListener() :
+		d_enabled(true)
+	{
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreGUIFrameListener::setCEGUIRenderEnabled(bool enabled)
+	{
+		d_enabled = enabled;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreGUIFrameListener::isCEGUIRenderEnabled() const
+	{
+		return d_enabled;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreGUIFrameListener::frameRenderingQueued(const Ogre::FrameEvent&)
+	{
+		if(d_enabled)
+			System::getSingleton().renderAllGUIContexts();
+
+		return true;
+	}
 #endif // CEGUI_USE_OGRE_COMPOSITOR2
 
 } // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/ResourceProvider.cpp
+++ b/cegui/src/RendererModules/Ogre/ResourceProvider.cpp
@@ -40,8 +40,7 @@ namespace CEGUI
 OgreResourceProvider::OgreResourceProvider()
 {
     // set deafult resource group for Ogre
-    d_defaultResourceGroup =
-        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME.c_str();
+    d_defaultResourceGroup = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME.c_str();
 }
 
 //----------------------------------------------------------------------------//

--- a/cegui/src/RendererModules/Ogre/Texture.cpp
+++ b/cegui/src/RendererModules/Ogre/Texture.cpp
@@ -25,19 +25,70 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/Texture.h"
+#ifdef CEGUI_OGRE_NEXT
 #include "CEGUI/Exceptions.h"
 #include "CEGUI/System.h"
 #include "CEGUI/RendererModules/Ogre/ImageCodec.h"
 #include "CEGUI/RendererModules/Ogre/OgreMacros.h"
-#include <OgreTextureManager.h>
-#include <OgreHardwarePixelBuffer.h>
+
+#include <OgreTextureGpuManager.h>
+#include <OgreTextureGpu.h>
+#include <OgreStagingTexture.h>
+#include <OgrePixelFormatGpuUtils.h>
+#include <OgreRoot.h>
+#include <OgreStringConverter.h>
 
 #include <cstdint>
+
+
+//#define CEGUI_OGRERENDERER_BLITFROMMEMORY_USESOURCEDATACOPY //define only for debug
 
 // Start of CEGUI namespace section
 namespace CEGUI
 {
 //----------------------------------------------------------------------------//
+
+//! For Debug only, to write test colours in textureData
+static void writeColorPatternToDataRGBA(Ogre::uint8* imageData, size_t dataSize, size_t bytesPerRow)
+{
+	memset(imageData, 50, dataSize);
+
+	int numberOfComtonents = 4;  //RGBA
+	int totalRows = dataSize / bytesPerRow;
+	int component = 0;
+	int currentRow = 0;
+	int bufferIndexRow = 0;
+	for(Ogre::uint32 bufferIndex = 0; bufferIndex < dataSize; ++bufferIndex)
+	{
+		float colour_red_percentage = (float)currentRow / (float)totalRows;
+		float colour_green_percentage = 0.0f;
+		float colour_blue_percentage = (float)bufferIndexRow / (float)bytesPerRow;
+		Ogre::uint8 colour_red = std::min(255u, (Ogre::uint32)(colour_red_percentage * 255.0f));
+		Ogre::uint8 colour_green = std::min(255u, (Ogre::uint32)(colour_green_percentage * 255.0f));
+		Ogre::uint8 colour_blue = std::min(255u, (Ogre::uint32)(colour_blue_percentage * 255.0f));
+
+		if(component == 0) //red
+			imageData[bufferIndex] = colour_red;
+		else if(component == 1) //green
+			imageData[bufferIndex] = colour_green;
+		else if(component == 2) //blue
+			imageData[bufferIndex] = colour_blue;
+		else //alpha
+			imageData[bufferIndex] = 255;
+
+		component++;
+		if(component >= numberOfComtonents)
+			component = 0;
+
+		bufferIndexRow++;
+		if(bufferIndexRow >= bytesPerRow)
+		{
+			currentRow++;
+			bufferIndexRow = 0;
+		}
+	}
+}
+
 // helper function to return byte size of image of given size in given format
 static size_t calculateDataSize(const Sizef size, Texture::PixelFormat fmt)
 {
@@ -71,6 +122,25 @@ static size_t calculateDataSize(const Sizef size, Texture::PixelFormat fmt)
     }
 }
 
+// helper function to return byte size of one pixel in given format
+static size_t calculateBytesPerPixel(Ogre::PixelFormatGpu pixelFormat)
+{
+	switch(pixelFormat)
+	{
+		case Ogre::PFG_RGBA8_UNORM:				return 4u;
+		
+		//Note: other formats are not supported by this class
+
+		//case Ogre::PFG_BC1_UNORM_SRGB:         return ;
+		//case Ogre::PFG_BC2_UNORM_SRGB:         return ;
+		//case Ogre::PFG_BC3_UNORM_SRGB:         return ;
+
+	default:
+		throw InvalidRequestException(
+			"Invalid pixel format (calculateBytesPerPixel)");
+	}
+}
+
 //----------------------------------------------------------------------------//
 std::uint32_t OgreTexture::d_textureNumber = 0;
 
@@ -80,7 +150,11 @@ OgreTexture::OgreTexture(const String& name) :
     d_size(0, 0),
     d_dataSize(0, 0),
     d_texelScaling(0, 0),
-    d_name(name)
+    d_name(name),
+	d_nameFile(),
+	d_textureGpu(0),
+	d_TextureDataRamCopy(0),
+	d_shallStoreTextureDataRamCopy(false)
 {
     createEmptyOgreTexture(Texture::PixelFormat::Rgba);
 }
@@ -92,7 +166,11 @@ OgreTexture::OgreTexture(const String& name, const String& filename,
     d_size(0, 0),
     d_dataSize(0, 0),
     d_texelScaling(0, 0),
-    d_name(name)
+    d_name(name),
+	d_nameFile(filename),
+	d_textureGpu(0),
+	d_TextureDataRamCopy(0),
+	d_shallStoreTextureDataRamCopy(false)
 {
     loadFromFile(filename, resourceGroup);
 }
@@ -103,40 +181,57 @@ OgreTexture::OgreTexture(const String& name, const Sizef& sz) :
     d_size(0, 0),
     d_dataSize(0, 0),
     d_texelScaling(0, 0),
-    d_name(name)
+    d_name(name),
+	d_nameFile(),
+	d_textureGpu(0),
+	d_TextureDataRamCopy(0),
+	d_shallStoreTextureDataRamCopy(false)
 {
-    d_texture = Ogre::TextureManager::getSingleton().createManual(
-        getUniqueName(), "General", Ogre::TEX_TYPE_2D,
-        sz.d_width, sz.d_height, 0,
-        Ogre::PF_A8B8G8R8);
+ 	createOgreTexture(Texture::PixelFormat::Rgba, sz.d_width, sz.d_height);
 
-    // throw exception if no texture was able to be created
-    if (OGRE_ISNULL(d_texture))
-        throw RendererException(
-            "Failed to create Texture object with spcecified size.");
 
-    d_size.d_width = static_cast<float>(d_texture->getWidth());
-    d_size.d_height = static_cast<float>(d_texture->getHeight());
+	d_size.d_width = static_cast<float>(d_textureGpu->getWidth());
+    d_size.d_height = static_cast<float>(d_textureGpu->getHeight());
     d_dataSize = sz;
     updateCachedScaleValues();
 }
 
 //----------------------------------------------------------------------------//
-OgreTexture::OgreTexture(const String& name, Ogre::TexturePtr& tex,
+OgreTexture::OgreTexture(const String& name, Ogre::TextureGpu* textureGpu,
                          bool take_ownership) :
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
     d_texelScaling(0, 0),
-    d_name(name)
+    d_name(name),
+	d_nameFile(),
+	d_textureGpu(0),
+	d_TextureDataRamCopy(0),
+	d_shallStoreTextureDataRamCopy(false)
 {
-    setOgreTexture(tex, take_ownership);
+    setOgreTexture(textureGpu, take_ownership);
 }
 
 //----------------------------------------------------------------------------//
 OgreTexture::~OgreTexture()
 {
     freeOgreTexture();
+	destroyTextureDataRamCopy();
+}
+
+void OgreTexture::destroyTextureDataRamCopy()
+{
+	if(d_TextureDataRamCopy)
+	{
+		OGRE_FREE_SIMD(d_TextureDataRamCopy, Ogre::MEMCATEGORY_RESOURCE);
+		d_TextureDataRamCopy = 0;
+	}
+}
+
+void OgreTexture::createEmptyTextureDataRamCopy(size_t dataSize)
+{
+	d_TextureDataRamCopy = reinterpret_cast<Ogre::uint8*>(OGRE_MALLOC_SIMD(dataSize, Ogre::MEMCATEGORY_RESOURCE));
+	memset(d_TextureDataRamCopy, 150, dataSize); //set to fixed value
 }
 
 //----------------------------------------------------------------------------//
@@ -178,7 +273,7 @@ void OgreTexture::loadFromFile(const String& filename,
     sys->getResourceProvider()->loadRawDataContainer(filename, texFile,
                                                      resourceGroup);
 
-    ImageCodec& ic(sys->getImageCodec());
+    CEGUI::ImageCodec& ic(sys->getImageCodec());
 
     // if we're using the integrated Ogre codec, set the file-type hint string
     if (ic.getIdentifierString().substr(0, 14)  == "OgreImageCodec")
@@ -190,7 +285,7 @@ void OgreTexture::loadFromFile(const String& filename,
         static_cast<OgreImageCodec&>(ic).setImageFileDataType(type);
     }
 
-    Texture* res = sys->getImageCodec().load(texFile, this);
+    CEGUI::Texture* res = sys->getImageCodec().load(texFile, this);
 
     // unload file data buffer
     sys->getResourceProvider()->unloadRawDataContainer(texFile);
@@ -206,45 +301,146 @@ void OgreTexture::loadFromFile(const String& filename,
 void OgreTexture::loadFromMemory(const void* buffer, const Sizef& buffer_size,
                                  PixelFormat pixel_format)
 {
-    using namespace Ogre;
-
+	if(d_isLinked) //do not write to linked textures
+		return;
+	
+	//This is for loading pictures and after resize of text textures
+	
     if (!isPixelFormatSupported(pixel_format))
         throw InvalidRequestException(
             "Data was supplied in an unsupported pixel format.");
 
-    const size_t byte_size = calculateDataSize(buffer_size, pixel_format);
+	if(pixel_format != PixelFormat::Rgba)
+		throw InvalidRequestException(
+			"Data was supplied in an unsupported pixel format. Must be RGBA (the only Format supported right now, use just such pictures)");
 
-    char* bufferCopy = new char[byte_size];
-    memcpy(bufferCopy, buffer, byte_size);
+	//Upload data to a TextureGpu
+	createOgreTexture(pixel_format, buffer_size.d_width, buffer_size.d_height);
+	
 
-    const Ogre::PixelBox* pixelBox = new Ogre::PixelBox(static_cast<std::uint32_t>(buffer_size.d_width), static_cast<std::uint32_t>(buffer_size.d_height),
-                                                        1, toOgrePixelFormat(pixel_format), bufferCopy);
-    createEmptyOgreTexture(pixel_format);
-    d_texture->freeInternalResources();
-    d_texture->setWidth(static_cast<std::uint32_t>(buffer_size.d_width));
-    d_texture->setHeight(static_cast<std::uint32_t>(buffer_size.d_height));
-    d_texture->setDepth(1);
-    d_texture->createInternalResources();
-    d_texture->getBuffer(0,0).get()->blitFromMemory(*pixelBox);
+	Ogre::TextureGpu* texture = d_textureGpu;
+	Ogre::TextureGpuManager* textureManager = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager();
 
-    // throw exception if no texture was able to be created
-    if (OGRE_ISNULL(d_texture))
-        throw RendererException(
-            "Failed to blit to Texture from memory.");
+	const Ogre::uint32 rowAlignment = calculateBytesPerPixel(texture->getPixelFormat()); //i.e. RGBA = 4
+	const size_t dataSizeOgreTexture = Ogre::PixelFormatGpuUtils::getSizeBytes(texture->getWidth(),
+		texture->getHeight(),
+		texture->getDepth(),
+		texture->getNumSlices(),
+		texture->getPixelFormat(),
+		rowAlignment);
 
-    d_size.d_width = static_cast<float>(d_texture->getWidth());
-    d_size.d_height = static_cast<float>(d_texture->getHeight());
-    d_dataSize = buffer_size;
-    updateCachedScaleValues();
+	const size_t bytesPerRow = texture->_getSysRamCopyBytesPerRow(0);
+	Ogre::uint8 *imageData = reinterpret_cast<Ogre::uint8*>(OGRE_MALLOC_SIMD(dataSizeOgreTexture, Ogre::MEMCATEGORY_RESOURCE));
+
+	// ... fill imageData ...
+	const size_t buffer_byte_size = calculateDataSize(buffer_size, pixel_format);
+	
+	if(buffer_byte_size == dataSizeOgreTexture)
+		memcpy(imageData, buffer, dataSizeOgreTexture);
+	else
+	{
+		throw std::runtime_error("Buffer size incorrect (OgreTexture::loadFromMemory)");
+		memset(imageData, 50, dataSizeOgreTexture);
+	}
+
+#if 0 //color set debug test - working
+	writeColorPatternToDataRGBA(imageData, dataSizeOgreTexture, bytesPerRow);
+#endif
+
+	//store texure ram copy
+	if(d_TextureDataRamCopy)
+	{
+		//d_TextureDataRamCopy must always be empty on loadFromMemory
+		throw std::runtime_error("d_TextureDataRamCopy must always be empty on loadFromMemory (OgreTexture::loadFromMemory)");
+		destroyTextureDataRamCopy();
+	}	   
+	if(d_shallStoreTextureDataRamCopy)
+	{
+		createEmptyTextureDataRamCopy(dataSizeOgreTexture);
+		memcpy(d_TextureDataRamCopy, imageData, dataSizeOgreTexture);
+	}
+
+	//-----------------------start upload to TextureGpu----------------------------------------
+	//Tell the texture we're going resident. The imageData pointer is only needed
+	//if the texture pageout strategy is GpuPageOutStrategy::AlwaysKeepSystemRamCopy
+	//which is in this example is not, so a nullptr would also work just fine.
+	texture->_transitionTo(Ogre::GpuResidency::Resident, imageData);
+	texture->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+	//We have to upload the data via a StagingTexture, which acts as an intermediate stash
+	//memory that is both visible to CPU and GPU.
+	Ogre::StagingTexture *stagingTexture = textureManager->getStagingTexture(texture->getWidth(),
+		texture->getHeight(),
+		texture->getDepth(),
+		texture->getNumSlices(),
+		texture->getPixelFormat());
+
+	//Call this function to indicate you're going to start calling mapRegion. startMapRegion
+	//must be called from main thread.
+	stagingTexture->startMapRegion();
+	//Map region of the staging texture. This function can be called from any thread after
+	//startMapRegion has already been called.
+	Ogre::TextureBox texBox = stagingTexture->mapRegion(texture->getWidth(), texture->getHeight(),
+		texture->getDepth(), texture->getNumSlices(),
+		texture->getPixelFormat());
+	texBox.copyFrom(imageData, texture->getWidth(), texture->getHeight(), bytesPerRow);
+	//stopMapRegion indicates you're done calling mapRegion. Call this from the main thread.
+	//It is your responsability to ensure you're done using all pointers returned from
+	//previous mapRegion calls, and that you won't call it again.
+	//You cannot upload until you've called this function.
+	//Do NOT call startMapRegion again until you're done with upload() calls.
+	stagingTexture->stopMapRegion();
+	//Upload an area of the staging texture into the texture. Must be done from main thread.
+	//The last bool parameter, 'skipSysRamCopy', is only relevant for AlwaysKeepSystemRamCopy
+	//textures, and we set it to true because we know it's already up to date. Otherwise
+	//it needs to be false.
+	stagingTexture->upload(texBox, texture, 0, 0, 0, true);
+	//Tell the TextureGpuManager we're done with this StagingTexture. Otherwise it will leak.
+	textureManager->removeStagingTexture(stagingTexture);
+	stagingTexture = 0;
+	//Do not free the pointer if texture's paging strategy is GpuPageOutStrategy::AlwaysKeepSystemRamCopy
+	OGRE_FREE_SIMD(imageData, Ogre::MEMCATEGORY_RESOURCE);
+	imageData = 0;
+	//This call is very important. It notifies the texture is fully ready for being displayed.
+	//Since we've scheduled the texture to become resident and pp until now, the texture knew
+	//it was being loaded and that only the metadata was certain. This call here signifies
+	//loading is done; and any registered listeners will be notified.
+#if OGRE_VERSION >= 0x020200 && OGRE_VERSION < 0x020300
+	texture->notifyDataIsReady(); // Must NOT call in Ogre 2.3 or later
+#endif
+	//------------------------------------------------------
+	
+	//Update cegui parameters:
+	d_size.d_width = static_cast<float>(texture->getWidth());
+	d_size.d_height = static_cast<float>(texture->getHeight());
+	d_dataSize = buffer_size;
+	updateCachedScaleValues();
 }
 
 //----------------------------------------------------------------------------//
 void OgreTexture::blitFromMemory(const void* sourceData, const Rectf& area)
 {
-    if (OGRE_ISNULL(d_texture)) // TODO: exception?
+	if(d_isLinked) //do not write to linked textures
+		return; 
+	
+	//this is used for text textures
+
+	/*Copies a region from normal memory to a region of this TextureGpu. 
+		The source image can be in any size.
+		@param sourceData MemoryData of source pixels  Format must be like the TextureGpu
+		@param area  Box describing the destination region in this TextureGpu
+		@remarks The source and destination regions dimensions don't have to match, in which
+		case scaling is done.This scaling is generally done using a bilinear filter in hardware.*/
+
+	if (!d_textureGpu) // TODO: exception?
         return;
 
-    // Ogre doesn't like null data, so skip if the sourceData is null and
+	/* Ogre::TextureGpu does not support blitFromMemory directly and does not allow to update only a spefic region of the texture. 
+		We therefore store a copy of the texture content in variable d_TextureDataRamCopy and blit to it (and upload it afterwards)
+		The textureDataRamCopy is activated on first blitFromMemory, as it is only needed for text-textures.
+		*/
+	d_shallStoreTextureDataRamCopy = true;
+
+	// Ogre doesn't like null data, so skip if the sourceData is null and
     // area is zero size
     if (sourceData == nullptr)
     {
@@ -259,40 +455,227 @@ void OgreTexture::blitFromMemory(const void* sourceData, const Rectf& area)
         throw RendererException("blitFromMemory source is null");
     }
 
+	//Uploading data to a TextureGpu
+	Ogre::TextureGpu* texture = d_textureGpu;
+	Ogre::TextureGpuManager* textureManager = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager();
 
-    // NOTE: const_cast because Ogre takes pointer to non-const here. Rather
-    // than allow that to dictate poor choices in our own APIs, we choose to
-    // address the issue as close to the source of the problem as possible.
-    Ogre::PixelBox pb(static_cast<Ogre::uint32>(area.getWidth()),
-                      static_cast<Ogre::uint32>(area.getHeight()),
-                      1,
-                      d_texture->getFormat(), const_cast<void*>(sourceData));
+	const Ogre::uint32 rowAlignment = calculateBytesPerPixel(texture->getPixelFormat()); //i.e. RGBA = 4
+	const size_t dataSizeOgreTexture = Ogre::PixelFormatGpuUtils::getSizeBytes(texture->getWidth(),
+		texture->getHeight(),
+		texture->getDepth(),
+		texture->getNumSlices(),
+		texture->getPixelFormat(),
+		rowAlignment);
 
-    Ogre::Box box(static_cast<Ogre::uint32>(area.left()),
-			      static_cast<Ogre::uint32>(area.top()),
-			      static_cast<Ogre::uint32>(area.right()),
-			      static_cast<Ogre::uint32>(area.bottom()) );
-    d_texture->getBuffer()->blitFromMemory(pb, box);
+	if(!d_TextureDataRamCopy && d_shallStoreTextureDataRamCopy)
+		createEmptyTextureDataRamCopy(dataSizeOgreTexture);
+
+	
+	Ogre::Box boxSourceData(static_cast<Ogre::uint32>(area.left()),
+		static_cast<Ogre::uint32>(area.top()),
+		static_cast<Ogre::uint32>(area.right()),
+		static_cast<Ogre::uint32>(area.bottom()));
+
+	size_t sourceDataBytesPerPixel = calculateBytesPerPixel(texture->getPixelFormat()); //i.e. RGBA = 4 - pixelformat must be same as the texture even if it is the sourcedata
+	size_t sourceDataBytesPerRow = boxSourceData.getWidth() * sourceDataBytesPerPixel;
+	size_t sourceDataBytesPerImage = sourceDataBytesPerRow * boxSourceData.getHeight();
+#ifdef CEGUI_OGRERENDERER_BLITFROMMEMORY_USESOURCEDATACOPY
+	Ogre::uint8* sourceDataCopy = reinterpret_cast<Ogre::uint8*>(OGRE_MALLOC_SIMD(sourceDataBytesPerImage,
+		Ogre::MEMCATEGORY_RESOURCE));
+	memcpy(sourceDataCopy, sourceData, sourceDataBytesPerImage);
+	
+	#if 0 //debug with fixed colours
+	writeColorPatternToDataRGBA(sourceDataCopy, sourceDataBytesPerImage, sourceDataBytesPerRow);
+	#endif
+
+	Ogre::TextureBox textureBoxSourceDataCopy(boxSourceData.getWidth(), boxSourceData.getHeight(), 1u, 1u,
+		sourceDataBytesPerPixel, sourceDataBytesPerRow, sourceDataBytesPerImage);
+	textureBoxSourceDataCopy.data = sourceDataCopy;
+#else
+	Ogre::TextureBox textureBoxSourceData(boxSourceData.getWidth(), boxSourceData.getHeight(), 1u, 1u,
+		sourceDataBytesPerPixel, sourceDataBytesPerRow, sourceDataBytesPerImage);
+	textureBoxSourceData.data = const_cast<void*>(sourceData);
+#endif
+
+	
+	//Ogre::uint8* imageData = reinterpret_cast<Ogre::uint8*>(OGRE_MALLOC_SIMD(dataSizeOgreTexture, Ogre::MEMCATEGORY_RESOURCE));
+	Ogre::uint8* imageData = 0; //imageData is not needed, but left here to match the Ogre Examples
+	// ... fill imageData ...
+#if 0 //color set debug test - working
+	memset(imageData, 50, dataSizeOgreTexture);
+	writeColorPatternToDataRGBA(imageData, dataSizeOgreTexture, bytesPerRow);
+#endif
+
+		
+	//-----------------------start upload to TextureGpu----------------------------------------
+	//Tell the texture we're going resident. The imageData pointer is only needed
+	//if the texture pageout strategy is GpuPageOutStrategy::AlwaysKeepSystemRamCopy
+	//which is in this example is not, so a nullptr would also work just fine.
+	//bool autoDeleteSysRamCopy = (texture->getGpuPageOutStrategy() != Ogre::GpuPageOutStrategy::AlwaysKeepSystemRamCopy);
+	bool autoDeleteSysRamCopy = true;
+	texture->_transitionTo(Ogre::GpuResidency::Resident, imageData, autoDeleteSysRamCopy);
+	texture->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+
+
+	//We have to upload the data via a StagingTexture, which acts as an intermediate stash
+	//memory that is both visible to CPU and GPU.
+	Ogre::StagingTexture *stagingTexture = textureManager->getStagingTexture(texture->getWidth(),
+		texture->getHeight(),
+		texture->getDepth(),
+		texture->getNumSlices(),
+		texture->getPixelFormat());
+
+	//Call this function to indicate you're going to start calling mapRegion. startMapRegion
+	//must be called from main thread.
+	stagingTexture->startMapRegion();
+	//Map region of the staging texture. This function can be called from any thread after
+	//startMapRegion has already been called.
+	Ogre::TextureBox texBox = stagingTexture->mapRegion(texture->getWidth(), texture->getHeight(),
+		texture->getDepth(), texture->getNumSlices(),
+		texture->getPixelFormat());
+	//Fill data start------------------------------------------------------------------------
+	const size_t bytesPerPixel = calculateBytesPerPixel(texture->getPixelFormat()); //i.e. RGBA = 4
+	const size_t bytesPerRow = texture->_getSysRamCopyBytesPerRow(0);
+	const size_t bytesPerImage = texture->_getSysRamCopyBytesPerImage(0);
+	Ogre::TextureBox textureBoxCeguiRamCopy(texture->getWidth(), texture->getHeight(), 1, 1, bytesPerPixel, bytesPerRow, bytesPerImage);
+	textureBoxCeguiRamCopy.data = d_TextureDataRamCopy;
+	
+#ifdef CEGUI_OGRERENDERER_BLITFROMMEMORY_USESOURCEDATACOPY
+	OgreTexture::blitFromMemory(textureBoxSourceDataCopy, textureBoxCeguiRamCopy, boxSourceData, texture->getPixelFormat());
+#else
+	OgreTexture::blitFromMemory(textureBoxSourceData, textureBoxCeguiRamCopy, boxSourceData, texture->getPixelFormat());
+#endif
+	texBox.copyFrom(d_TextureDataRamCopy, texture->getWidth(), texture->getHeight(), bytesPerRow);
+	//Fill data end------------------------------------------------------------------------	
+	//stopMapRegion indicates you're done calling mapRegion. Call this from the main thread.
+	//It is your responsability to ensure you're done using all pointers returned from
+	//previous mapRegion calls, and that you won't call it again.
+	//You cannot upload until you've called this function.
+	//Do NOT call startMapRegion again until you're done with upload() calls.
+	stagingTexture->stopMapRegion();
+	//Upload an area of the staging texture into the texture. Must be done from main thread.
+	//The last bool parameter, 'skipSysRamCopy', is only relevant for AlwaysKeepSystemRamCopy
+	//textures, and we set it to true because we know it's already up to date. Otherwise
+	//it needs to be false.
+	stagingTexture->upload(texBox, texture, 0, 0, 0, true);
+	//Tell the TextureGpuManager we're done with this StagingTexture. Otherwise it will leak.
+	textureManager->removeStagingTexture(stagingTexture);
+	stagingTexture = 0;
+
+	//Do not free the pointer if texture's paging strategy is GpuPageOutStrategy::AlwaysKeepSystemRamCopy
+	//OGRE_FREE_SIMD(imageData, Ogre::MEMCATEGORY_RESOURCE);
+	//imageData = 0;
+
+#ifdef CEGUI_OGRERENDERER_BLITFROMMEMORY_USESOURCEDATACOPY
+	OGRE_FREE_SIMD(sourceDataCopy, Ogre::MEMCATEGORY_RESOURCE);
+	sourceDataCopy = 0;
+#endif
+	//This call is very important. It notifies the texture is fully ready for being displayed.
+	//Since we've scheduled the texture to become resident and pp until now, the texture knew
+	//it was being loaded and that only the metadata was certain. This call here signifies
+	//loading is done; and any registered listeners will be notified.
+	
+#if OGRE_VERSION >= 0x020200 && OGRE_VERSION < 0x020300
+	texture->notifyDataIsReady(); // Must NOT call in Ogre 2.3 or later
+#endif
+}
+
+void OgreTexture::blitFromMemory(Ogre::TextureBox& src, Ogre::TextureBox& target, Ogre::Box& targetArea, Ogre::PixelFormatGpu pixelFormat)
+{
+	const Ogre::uint32 srcZorSlice = src.getZOrSlice();
+	const Ogre::uint32 dstZorSlice = target.getZOrSlice();
+	const Ogre::uint32 finalDepthOrSlices = src.getDepthOrSlices();
+
+	const Ogre::uint32 rowAlignment = calculateBytesPerPixel(pixelFormat); //i.e. RGBA = 4
+	Ogre::uint32 width_scaled = targetArea.getWidth();
+	Ogre::uint32 height_scaled = targetArea.getHeight();
+	const size_t dataSizeScaled = Ogre::PixelFormatGpuUtils::getSizeBytes(width_scaled, height_scaled,
+		1u,
+		1u,
+		pixelFormat,
+		rowAlignment);
+
+	Ogre::uint8* scaledData = reinterpret_cast<Ogre::uint8*>(OGRE_MALLOC_SIMD(dataSizeScaled, Ogre::MEMCATEGORY_RESOURCE));
+
+	size_t scaledDataBytesPerPixel = calculateBytesPerPixel(pixelFormat); //i.e. RGBA = 4
+	size_t scaledDataBytesPerRow = width_scaled * scaledDataBytesPerPixel;
+	size_t scaledDataBytesPerImage = scaledDataBytesPerRow * height_scaled;
+
+	Ogre::TextureBox scaledTextureBox(width_scaled, height_scaled, 1u, 1u,
+		pixelFormat, scaledDataBytesPerRow, scaledDataBytesPerImage);
+	scaledTextureBox.data = reinterpret_cast<void*>(scaledData);
+
+	Ogre::Image2::scale(src, pixelFormat, scaledTextureBox, pixelFormat);
+
+	// now copy to target Area:
+	if(!target.isCompressed())
+	{
+		//Copy row by row, uncompressed.
+
+		Ogre::uint32 finalY = targetArea.getHeight();
+
+		size_t areaBytesPerPixel = calculateBytesPerPixel(pixelFormat); 
+		size_t areaBytesPerRow = areaBytesPerPixel * targetArea.getWidth();
+
+		size_t copySpaceXPossible = areaBytesPerPixel * (target.width - targetArea.left);
+		size_t finalBytesPerRow = std::min(copySpaceXPossible, areaBytesPerRow);
+
+		for(size_t _z = 0; _z < finalDepthOrSlices; ++_z)
+		{
+			for(size_t _y = 0; _y < finalY; ++_y)
+			{
+#if 0 //debug
+				if(targetArea.left + targetArea.getWidth() >= target.bytesPerRow)
+				{
+					throw std::runtime_error("copy out of bounds (OgreTexture::blitFromMemory)");
+				}
+
+				if(targetArea.left + targetArea.getWidth() >= target.bytesPerRow)
+				{
+					throw std::runtime_error("copy out of bounds (OgreTexture::blitFromMemory)");
+				}
+
+				if(scaledTextureBox.x != 0 || scaledTextureBox.y != 0)
+				{
+					throw std::runtime_error("copy out of bounds (OgreTexture::blitFromMemory)");
+				}
+
+				if(target.x != 0 || target.y != 0)
+				{
+					throw std::runtime_error("copy out of bounds (OgreTexture::blitFromMemory)");
+				}
+#endif
+				const void *srcData = scaledTextureBox.at(scaledTextureBox.x, _y + scaledTextureBox.y, _z + srcZorSlice);
+				void *dstData = target.at(target.x + targetArea.left, _y + target.y + targetArea.top, _z + dstZorSlice);
+				memcpy(dstData, srcData, finalBytesPerRow);
+			}
+		}
+	}
+	else
+	{
+		throw std::runtime_error("Compressed image format not supported. (OgreTexture::blitFromMemory)");
+	}
+
+	OGRE_FREE_SIMD(scaledData, Ogre::MEMCATEGORY_RESOURCE);
 }
 
 //----------------------------------------------------------------------------//
 void OgreTexture::blitToMemory(void* targetData)
 {
-    if (OGRE_ISNULL(d_texture)) // TODO: exception?
-        return;
-
-    Ogre::PixelBox pb(static_cast<std::uint32_t>(d_size.d_width), static_cast<std::uint32_t>(d_size.d_height),
-                      1, d_texture->getFormat(), targetData);
-    d_texture->getBuffer()->blitToMemory(pb);
+	//Not implemented
 }
 
 //----------------------------------------------------------------------------//
 void OgreTexture::freeOgreTexture()
 {
-    if (!OGRE_ISNULL(d_texture) && !d_isLinked)
-        Ogre::TextureManager::getSingleton().remove(d_texture->getHandle());
+   if(d_textureGpu && !d_isLinked)
+	{
+		Ogre::TextureGpuManager* textureGpuManager = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager();
+		textureGpuManager->destroyTexture(d_textureGpu);
+		d_textureGpu = 0;		
+	}
 
-    OGRE_RESET(d_texture);
+   destroyTextureDataRamCopy();
 }
 
 //----------------------------------------------------------------------------//
@@ -305,10 +688,8 @@ Ogre::String OgreTexture::getUniqueName()
         return strstream.str();
     #endif
     #if OGRE_VERSION >= 0x10A00
-        Ogre::StringStream strstream;
-        strstream << "_cegui_ogre_" << d_textureNumber++;
-
-        return strstream.str();
+        Ogre::String name("_cegui_ogre_" + Ogre::StringConverter::toString(d_textureNumber++));
+        return name;
     #endif
 }
 
@@ -341,17 +722,17 @@ void OgreTexture::updateCachedScaleValues()
 }
 
 //----------------------------------------------------------------------------//
-void OgreTexture::setOgreTexture(Ogre::TexturePtr texture, bool take_ownership)
+void OgreTexture::setOgreTexture(Ogre::TextureGpu* textureGpu, bool take_ownership)
 {
     freeOgreTexture();
 
-    d_texture = texture;
+    d_textureGpu = textureGpu;
     d_isLinked = !take_ownership;
 
-    if (!OGRE_ISNULL(d_texture))
+    if (d_textureGpu)
     {
-        d_size.d_width = static_cast<float>(d_texture->getWidth());
-        d_size.d_height= static_cast<float>(d_texture->getHeight());
+        d_size.d_width = static_cast<float>(d_textureGpu->getWidth());
+        d_size.d_height= static_cast<float>(d_textureGpu->getHeight());
         d_dataSize = d_size;
     }
     else
@@ -361,9 +742,9 @@ void OgreTexture::setOgreTexture(Ogre::TexturePtr texture, bool take_ownership)
 }
 
 //----------------------------------------------------------------------------//
-Ogre::TexturePtr OgreTexture::getOgreTexture() const
+Ogre::TextureGpu* OgreTexture::getOgreTexture() const
 {
-    return d_texture;
+    return d_textureGpu;
 }
 
 //----------------------------------------------------------------------------//
@@ -371,10 +752,8 @@ bool OgreTexture::isPixelFormatSupported(const PixelFormat fmt) const
 {
     try
     {
-        return Ogre::TextureManager::getSingleton().
-            isEquivalentFormatSupported(Ogre::TEX_TYPE_2D,
-                                        toOgrePixelFormat(fmt),
-                                        Ogre::TU_DEFAULT);
+		return Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager()->checkSupport(toOgrePixelFormat(fmt),
+			Ogre::TextureTypes::Type2D, Ogre::TextureFlags::ManualTexture);
     }
     catch (InvalidRequestException&)
     {
@@ -383,19 +762,19 @@ bool OgreTexture::isPixelFormatSupported(const PixelFormat fmt) const
 }
 
 //----------------------------------------------------------------------------//
-Ogre::PixelFormat OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
+Ogre::PixelFormatGpu OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
 {
     switch (fmt)
     {
-        case Texture::PixelFormat::Rgba:       return Ogre::PF_A8B8G8R8;
-        case Texture::PixelFormat::Rgb:        return Ogre::PF_B8G8R8;
-        case Texture::PixelFormat::Rgb565:    return Ogre::PF_R5G6B5;
+        case Texture::PixelFormat::Rgba:       return Ogre::PFG_RGBA8_UNORM;
+        //case Texture::PixelFormat::Rgb:        return Ogre::PFG_RGBA8_UNORM;
+        /*case Texture::PixelFormat::Rgb565:    return Ogre::PF_R5G6B5;
         case Texture::PixelFormat::Rgba4444:  return Ogre::PF_A4R4G4B4;
         case Texture::PixelFormat::Pvrtc2:     return Ogre::PF_PVRTC_RGBA2;
-        case Texture::PixelFormat::Pvrtc4:     return Ogre::PF_PVRTC_RGBA4;
-        case Texture::PixelFormat::RgbaDxt1:  return Ogre::PF_DXT1;
-        case Texture::PixelFormat::RgbaDxt3:  return Ogre::PF_DXT3;
-        case Texture::PixelFormat::RgbaDxt5:  return Ogre::PF_DXT5;
+        case Texture::PixelFormat::Pvrtc4:     return Ogre::PF_PVRTC_RGBA4;*/
+        case Texture::PixelFormat::RgbaDxt1:  return Ogre::PFG_BC1_UNORM;
+        case Texture::PixelFormat::RgbaDxt3:  return Ogre::PFG_BC2_UNORM;
+        case Texture::PixelFormat::RgbaDxt5:  return Ogre::PFG_BC3_UNORM;
 
         default:
             throw InvalidRequestException(
@@ -404,22 +783,22 @@ Ogre::PixelFormat OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
 }
 
 //----------------------------------------------------------------------------//
-Texture::PixelFormat OgreTexture::fromOgrePixelFormat(
-                                            const Ogre::PixelFormat fmt)
+Texture::PixelFormat OgreTexture::fromOgrePixelFormat(const Ogre::PixelFormatGpu fmt)
 {
     switch (fmt)
     {
-        case Ogre::PF_A8R8G8B8:     return Texture::PixelFormat::Rgba;
-        case Ogre::PF_A8B8G8R8:     return Texture::PixelFormat::Rgba;
-        case Ogre::PF_R8G8B8:       return Texture::PixelFormat::Rgb;
+		case Ogre::PFG_RGBA8_UNORM:				return Texture::PixelFormat::Rgba;
+		//case Ogre::PFG_RGBA8_UNORM_SRGB:		return Texture::PixelFormat::Rgba;
+        //case Ogre::PF_A8B8G8R8:     return Texture::PixelFormat::Rgba;
+        /*case Ogre::PF_R8G8B8:       return Texture::PixelFormat::Rgb;
         case Ogre::PF_B8G8R8:       return Texture::PixelFormat::Rgb;
         case Ogre::PF_R5G6B5:       return Texture::PixelFormat::Rgb565;
         case Ogre::PF_A4R4G4B4:     return Texture::PixelFormat::Rgba4444;
         case Ogre::PF_PVRTC_RGBA2:  return Texture::PixelFormat::Pvrtc2;
-        case Ogre::PF_PVRTC_RGBA4:  return Texture::PixelFormat::Pvrtc4;
-        case Ogre::PF_DXT1:         return Texture::PixelFormat::RgbaDxt1;
-        case Ogre::PF_DXT3:         return Texture::PixelFormat::RgbaDxt3;
-        case Ogre::PF_DXT5:         return Texture::PixelFormat::RgbaDxt5;
+        case Ogre::PF_PVRTC_RGBA4:  return Texture::PixelFormat::Pvrtc4;*/
+        case Ogre::PFG_BC1_UNORM_SRGB:         return Texture::PixelFormat::RgbaDxt1;
+        case Ogre::PFG_BC2_UNORM_SRGB:         return Texture::PixelFormat::RgbaDxt3;
+        case Ogre::PFG_BC3_UNORM_SRGB:         return Texture::PixelFormat::RgbaDxt5;
 
         default:
             throw InvalidRequestException(
@@ -430,14 +809,459 @@ Texture::PixelFormat OgreTexture::fromOgrePixelFormat(
 //----------------------------------------------------------------------------//
 void OgreTexture::createEmptyOgreTexture(PixelFormat pixel_format)
 {
-    // try to create a Ogre::Texture with given dimensions
-    d_texture = Ogre::TextureManager::getSingleton().createManual(
-        getUniqueName(), "General", Ogre::TEX_TYPE_2D,
-        1, 1, 0,
-        toOgrePixelFormat(pixel_format));
+	createOgreTexture(pixel_format, 1, 1);
+}
+
+void OgreTexture::createOgreTexture(PixelFormat pixel_format, Ogre::uint32 width, Ogre::uint32 height)
+{
+	freeOgreTexture();
+
+	if(d_TextureDataRamCopy)
+		throw std::runtime_error("Error d_TextureDataRamCopy must be empty when creating new texture (OgreTexture::createOgreTexture)");
+		
+	Ogre::uint32 textureFlags = Ogre::TextureFlags::ManualTexture;
+	Ogre::GpuPageOutStrategy::GpuPageOutStrategy gpuPageOutStrategy = Ogre::GpuPageOutStrategy::Discard;
+
+	d_textureGpu = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager()->createOrRetrieveTexture(
+		getUniqueName(),
+		gpuPageOutStrategy,
+		textureFlags,
+		Ogre::TextureTypes::Type2D,
+		"General"
+	);
+
+	// throw exception if no texture was able to be created
+	if(!d_textureGpu)
+		throw RendererException(
+			"Failed to create Texture object");
+
+	d_textureGpu->setPixelFormat(toOgrePixelFormat(pixel_format));
+	d_textureGpu->setTextureType(Ogre::TextureTypes::Type2D);
+	d_textureGpu->setNumMipmaps(1u);
+	d_textureGpu->setResolution(width, height);
 }
 
 
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/Exceptions.h"
+#include "CEGUI/System.h"
+#include "CEGUI/RendererModules/Ogre/ImageCodec.h"
+#include "CEGUI/RendererModules/Ogre/OgreMacros.h"
+#include <OgreTextureManager.h>
+#include <OgreHardwarePixelBuffer.h>
+
+#include <cstdint>
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+	//----------------------------------------------------------------------------//
+	// helper function to return byte size of image of given size in given format
+	static size_t calculateDataSize(const Sizef size, Texture::PixelFormat fmt)
+	{
+		switch(fmt)
+		{
+		case Texture::PixelFormat::Rgba:
+			return static_cast<size_t>(size.d_width * size.d_height * 4);
+
+		case Texture::PixelFormat::Rgb:
+			return static_cast<size_t>(size.d_width * size.d_height * 3);
+
+		case Texture::PixelFormat::Rgb565:
+		case Texture::PixelFormat::Rgba4444:
+			return static_cast<size_t>(size.d_width * size.d_height * 2);
+
+		case Texture::PixelFormat::Pvrtc2:
+			return (static_cast<size_t>(size.d_width * size.d_height) * 2 + 7) / 8;
+
+		case Texture::PixelFormat::Pvrtc4:
+			return (static_cast<size_t>(size.d_width * size.d_height) * 4 + 7) / 8;
+
+		case Texture::PixelFormat::RgbaDxt1:
+			return static_cast<size_t>(std::ceil(size.d_width / 4) * std::ceil(size.d_height / 4) * 8);
+
+		case Texture::PixelFormat::RgbaDxt3:
+		case Texture::PixelFormat::RgbaDxt5:
+			return static_cast<size_t>(std::ceil(size.d_width / 4) * std::ceil(size.d_height / 4) * 16);
+
+		default:
+			return 0;
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	std::uint32_t OgreTexture::d_textureNumber = 0;
+
+	//----------------------------------------------------------------------------//
+	OgreTexture::OgreTexture(const String& name) :
+		d_isLinked(false),
+		d_size(0, 0),
+		d_dataSize(0, 0),
+		d_texelScaling(0, 0),
+		d_name(name)
+	{
+		createEmptyOgreTexture(Texture::PixelFormat::Rgba);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreTexture::OgreTexture(const String& name, const String& filename,
+		const String& resourceGroup) :
+		d_isLinked(false),
+		d_size(0, 0),
+		d_dataSize(0, 0),
+		d_texelScaling(0, 0),
+		d_name(name)
+	{
+		loadFromFile(filename, resourceGroup);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreTexture::OgreTexture(const String& name, const Sizef& sz) :
+		d_isLinked(false),
+		d_size(0, 0),
+		d_dataSize(0, 0),
+		d_texelScaling(0, 0),
+		d_name(name)
+	{
+		d_texture = Ogre::TextureManager::getSingleton().createManual(
+			getUniqueName(), "General", Ogre::TEX_TYPE_2D,
+			sz.d_width, sz.d_height, 0,
+			Ogre::PF_A8B8G8R8);
+
+		// throw exception if no texture was able to be created
+		if(OGRE_ISNULL(d_texture))
+			throw RendererException(
+				"Failed to create Texture object with spcecified size.");
+
+		d_size.d_width = static_cast<float>(d_texture->getWidth());
+		d_size.d_height = static_cast<float>(d_texture->getHeight());
+		d_dataSize = sz;
+		updateCachedScaleValues();
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreTexture::OgreTexture(const String& name, Ogre::TexturePtr& tex,
+		bool take_ownership) :
+		d_isLinked(false),
+		d_size(0, 0),
+		d_dataSize(0, 0),
+		d_texelScaling(0, 0),
+		d_name(name)
+	{
+		setOgreTexture(tex, take_ownership);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreTexture::~OgreTexture()
+	{
+		freeOgreTexture();
+	}
+
+	//----------------------------------------------------------------------------//
+	const String& OgreTexture::getName() const
+	{
+		return d_name;
+	}
+
+	//----------------------------------------------------------------------------//
+	const Sizef& OgreTexture::getSize() const
+	{
+		return d_size;
+	}
+
+	//----------------------------------------------------------------------------//
+	const Sizef& OgreTexture::getOriginalDataSize() const
+	{
+		return d_dataSize;
+	}
+
+	//----------------------------------------------------------------------------//
+	const glm::vec2& OgreTexture::getTexelScaling() const
+	{
+		return d_texelScaling;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::loadFromFile(const String& filename,
+		const String& resourceGroup)
+	{
+		// get and check existence of CEGUI::System object
+		System* sys = System::getSingletonPtr();
+		if(!sys)
+			throw RendererException(
+				"CEGUI::System object has not been created!");
+
+		// load file to memory via resource provider
+		RawDataContainer texFile;
+		sys->getResourceProvider()->loadRawDataContainer(filename, texFile,
+			resourceGroup);
+
+		ImageCodec& ic(sys->getImageCodec());
+
+		// if we're using the integrated Ogre codec, set the file-type hint string
+		if(ic.getIdentifierString().substr(0, 14) == "OgreImageCodec")
+		{
+			String type;
+			String::size_type i = filename.find_last_of(".");
+			if(i != String::npos && filename.length() - i > 1)
+				type = filename.substr(i + 1);
+			static_cast<OgreImageCodec&>(ic).setImageFileDataType(type);
+		}
+
+		Texture* res = sys->getImageCodec().load(texFile, this);
+
+		// unload file data buffer
+		sys->getResourceProvider()->unloadRawDataContainer(texFile);
+
+		// throw exception if data was load loaded to texture.
+		if(!res)
+			throw RendererException(
+				sys->getImageCodec().getIdentifierString() +
+				" failed to load image '" + filename + "'.");
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::loadFromMemory(const void* buffer, const Sizef& buffer_size,
+		PixelFormat pixel_format)
+	{
+		using namespace Ogre;
+
+		if(!isPixelFormatSupported(pixel_format))
+			throw InvalidRequestException(
+				"Data was supplied in an unsupported pixel format.");
+
+		const size_t byte_size = calculateDataSize(buffer_size, pixel_format);
+
+		char* bufferCopy = new char[byte_size];
+		memcpy(bufferCopy, buffer, byte_size);
+
+		const Ogre::PixelBox* pixelBox = new Ogre::PixelBox(static_cast<std::uint32_t>(buffer_size.d_width), static_cast<std::uint32_t>(buffer_size.d_height),
+			1, toOgrePixelFormat(pixel_format), bufferCopy);
+		createEmptyOgreTexture(pixel_format);
+		d_texture->freeInternalResources();
+		d_texture->setWidth(static_cast<std::uint32_t>(buffer_size.d_width));
+		d_texture->setHeight(static_cast<std::uint32_t>(buffer_size.d_height));
+		d_texture->setDepth(1);
+		d_texture->createInternalResources();
+		d_texture->getBuffer(0, 0).get()->blitFromMemory(*pixelBox);
+
+		// throw exception if no texture was able to be created
+		if(OGRE_ISNULL(d_texture))
+			throw RendererException(
+				"Failed to blit to Texture from memory.");
+
+		d_size.d_width = static_cast<float>(d_texture->getWidth());
+		d_size.d_height = static_cast<float>(d_texture->getHeight());
+		d_dataSize = buffer_size;
+		updateCachedScaleValues();
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::blitFromMemory(const void* sourceData, const Rectf& area)
+	{
+		if(OGRE_ISNULL(d_texture)) // TODO: exception?
+			return;
+
+		// Ogre doesn't like null data, so skip if the sourceData is null and
+		// area is zero size
+		if(sourceData == nullptr)
+		{
+			if(static_cast<int>(area.getWidth()) == 0 &&
+				static_cast<int>(area.getHeight()) == 0)
+			{
+				return;
+			}
+
+			// Here we are trying to write to a non-zero size area with null
+			// ptr for data
+			throw RendererException("blitFromMemory source is null");
+		}
+
+
+		// NOTE: const_cast because Ogre takes pointer to non-const here. Rather
+		// than allow that to dictate poor choices in our own APIs, we choose to
+		// address the issue as close to the source of the problem as possible.
+		Ogre::PixelBox pb(static_cast<Ogre::uint32>(area.getWidth()),
+			static_cast<Ogre::uint32>(area.getHeight()),
+			1,
+			d_texture->getFormat(), const_cast<void*>(sourceData));
+
+		Ogre::Box box(static_cast<Ogre::uint32>(area.left()),
+			static_cast<Ogre::uint32>(area.top()),
+			static_cast<Ogre::uint32>(area.right()),
+			static_cast<Ogre::uint32>(area.bottom()));
+		d_texture->getBuffer()->blitFromMemory(pb, box);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::blitToMemory(void* targetData)
+	{
+		if(OGRE_ISNULL(d_texture)) // TODO: exception?
+			return;
+
+		Ogre::PixelBox pb(static_cast<std::uint32_t>(d_size.d_width), static_cast<std::uint32_t>(d_size.d_height),
+			1, d_texture->getFormat(), targetData);
+		d_texture->getBuffer()->blitToMemory(pb);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::freeOgreTexture()
+	{
+		if(!OGRE_ISNULL(d_texture) && !d_isLinked)
+			Ogre::TextureManager::getSingleton().remove(d_texture->getHandle());
+
+		OGRE_RESET(d_texture);
+	}
+
+	//----------------------------------------------------------------------------//
+	Ogre::String OgreTexture::getUniqueName()
+	{
+#if OGRE_VERSION < 0x10A00
+		Ogre::StringUtil::StrStreamType strstream;
+		strstream << "_cegui_ogre_" << d_textureNumber++;
+
+		return strstream.str();
+#endif
+#if OGRE_VERSION >= 0x10A00
+		Ogre::StringStream strstream;
+		strstream << "_cegui_ogre_" << d_textureNumber++;
+
+		return strstream.str();
+#endif
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::updateCachedScaleValues()
+	{
+		//
+		// calculate what to use for x scale
+		//
+		const float orgW = d_dataSize.d_width;
+		const float texW = d_size.d_width;
+
+		// if texture and original data width are the same, scale is based
+		// on the original size.
+		// if texture is wider (and source data was not stretched), scale
+		// is based on the size of the resulting texture.
+		d_texelScaling.x = 1.0f / ((orgW == texW) ? orgW : texW);
+
+		//
+		// calculate what to use for y scale
+		//
+		const float orgH = d_dataSize.d_height;
+		const float texH = d_size.d_height;
+
+		// if texture and original data height are the same, scale is based
+		// on the original size.
+		// if texture is taller (and source data was not stretched), scale
+		// is based on the size of the resulting texture.
+		d_texelScaling.y = 1.0f / ((orgH == texH) ? orgH : texH);
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::setOgreTexture(Ogre::TexturePtr texture, bool take_ownership)
+	{
+		freeOgreTexture();
+
+		d_texture = texture;
+		d_isLinked = !take_ownership;
+
+		if(!OGRE_ISNULL(d_texture))
+		{
+			d_size.d_width = static_cast<float>(d_texture->getWidth());
+			d_size.d_height = static_cast<float>(d_texture->getHeight());
+			d_dataSize = d_size;
+		}
+		else
+			d_size = d_dataSize = Sizef(0, 0);
+
+		updateCachedScaleValues();
+	}
+
+	//----------------------------------------------------------------------------//
+	Ogre::TexturePtr OgreTexture::getOgreTexture() const
+	{
+		return d_texture;
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreTexture::isPixelFormatSupported(const PixelFormat fmt) const
+	{
+		try
+		{
+			return Ogre::TextureManager::getSingleton().
+				isEquivalentFormatSupported(Ogre::TEX_TYPE_2D,
+					toOgrePixelFormat(fmt),
+					Ogre::TU_DEFAULT);
+		}
+		catch(InvalidRequestException&)
+		{
+			return false;
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	Ogre::PixelFormat OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
+	{
+		switch(fmt)
+		{
+		case Texture::PixelFormat::Rgba:       return Ogre::PF_A8B8G8R8;
+		case Texture::PixelFormat::Rgb:        return Ogre::PF_B8G8R8;
+		case Texture::PixelFormat::Rgb565:    return Ogre::PF_R5G6B5;
+		case Texture::PixelFormat::Rgba4444:  return Ogre::PF_A4R4G4B4;
+		case Texture::PixelFormat::Pvrtc2:     return Ogre::PF_PVRTC_RGBA2;
+		case Texture::PixelFormat::Pvrtc4:     return Ogre::PF_PVRTC_RGBA4;
+		case Texture::PixelFormat::RgbaDxt1:  return Ogre::PF_DXT1;
+		case Texture::PixelFormat::RgbaDxt3:  return Ogre::PF_DXT3;
+		case Texture::PixelFormat::RgbaDxt5:  return Ogre::PF_DXT5;
+
+		default:
+			throw InvalidRequestException(
+				"Invalid pixel format translation.");
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture::PixelFormat OgreTexture::fromOgrePixelFormat(
+		const Ogre::PixelFormat fmt)
+	{
+		switch(fmt)
+		{
+		case Ogre::PF_A8R8G8B8:     return Texture::PixelFormat::Rgba;
+		case Ogre::PF_A8B8G8R8:     return Texture::PixelFormat::Rgba;
+		case Ogre::PF_R8G8B8:       return Texture::PixelFormat::Rgb;
+		case Ogre::PF_B8G8R8:       return Texture::PixelFormat::Rgb;
+		case Ogre::PF_R5G6B5:       return Texture::PixelFormat::Rgb565;
+		case Ogre::PF_A4R4G4B4:     return Texture::PixelFormat::Rgba4444;
+		case Ogre::PF_PVRTC_RGBA2:  return Texture::PixelFormat::Pvrtc2;
+		case Ogre::PF_PVRTC_RGBA4:  return Texture::PixelFormat::Pvrtc4;
+		case Ogre::PF_DXT1:         return Texture::PixelFormat::RgbaDxt1;
+		case Ogre::PF_DXT3:         return Texture::PixelFormat::RgbaDxt3;
+		case Ogre::PF_DXT5:         return Texture::PixelFormat::RgbaDxt5;
+
+		default:
+			throw InvalidRequestException(
+				"Invalid pixel format translation.");
+		}
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTexture::createEmptyOgreTexture(PixelFormat pixel_format)
+	{
+		// try to create a Ogre::Texture with given dimensions
+		d_texture = Ogre::TextureManager::getSingleton().createManual(
+			getUniqueName(), "General", Ogre::TEX_TYPE_2D,
+			1, 1, 0,
+			toOgrePixelFormat(pixel_format));
+	}
+
+
+	//----------------------------------------------------------------------------//
+
+} // End of  CEGUI namespace section
+
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/TextureTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/TextureTarget.cpp
@@ -25,12 +25,15 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/TextureTarget.h"
+#ifdef CEGUI_OGRE_NEXT
 #include "CEGUI/RendererModules/Ogre/Texture.h"
 #include "CEGUI/PropertyHelper.h"
 
-#include <OgreTextureManager.h>
-#include <OgreHardwarePixelBuffer.h>
-#include <OgreRenderTexture.h>
+#include <OgreTextureGpuManager.h>
+#include <OgreStagingTexture.h>
+#include <OgreAsyncTextureTicket.h>
+#include <OgreRoot.h>
+#include <OgreTextureGpu.h>
 #include <OgreRenderSystem.h>
 #include <OgreViewport.h>
 
@@ -46,7 +49,7 @@ std::uint32_t OgreTextureTarget::s_textureNumber = 0;
 OgreTextureTarget::OgreTextureTarget(OgreRenderer& owner,
                                      Ogre::RenderSystem& rs,
                                      bool addStencilBuffer) :
-    OgreRenderTarget(owner, rs),
+    OgreRenderTarget(owner, rs, true),
     TextureTarget(addStencilBuffer),
     d_CEGUITexture(0)
 {
@@ -72,21 +75,7 @@ bool OgreTextureTarget::isImageryCache() const
 //----------------------------------------------------------------------------//
 void OgreTextureTarget::clear()
 {
-    if (!d_viewportValid)
-        updateViewport();
-
-    Ogre::Viewport* const saved_vp = d_renderSystem._getViewport();
-
-    d_renderSystem._setViewport(d_viewport);
-    d_renderSystem.clearFrameBuffer(Ogre::FBT_COLOUR,
-        Ogre::ColourValue(0, 0, 0, 0));
-
-#if OGRE_VERSION < 0x10800
-    if (saved_vp)
-        d_renderSystem._setViewport(saved_vp);
-#else
-    d_renderSystem._setViewport(saved_vp);
-#endif
+   	//please note that we are not able to clear the texture at this point. We will instead clear the first draw of an GemoetryBuffer in a qeue to Ogre::ColourValue(0, 0, 0, 0)
 }
 
 //----------------------------------------------------------------------------//
@@ -102,35 +91,37 @@ void OgreTextureTarget::declareRenderSize(const Sizef& sz)
     if ((d_area.getWidth() >= sz.d_width) && (d_area.getHeight() >=sz.d_height))
         return;
 
-    Ogre::TexturePtr rttTex = Ogre::TextureManager::getSingleton().createManual(OgreTexture::getUniqueName(),
-                                                                                Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
-                                                                                Ogre::TEX_TYPE_2D,
-                                                                                static_cast<Ogre::uint>(sz.d_width),
-                                                                                static_cast<Ogre::uint>(sz.d_height),
-                                                                                1,
-                                                                                0, 
-                                                                                Ogre::PF_A8R8G8B8,
-                                                                                Ogre::TU_RENDERTARGET);
-
-    d_renderTarget = rttTex->getBuffer()->getRenderTarget();
+	Ogre::TextureGpu* rttTex = Ogre::Root::getSingleton().getRenderSystem()->getTextureGpuManager()->createTexture(
+		OgreTexture::getUniqueName() + " TextureTarget",
+		Ogre::GpuPageOutStrategy::Discard,
+		Ogre::TextureFlags::RenderToTexture,
+		Ogre::TextureTypes::Type2D,
+		"General"
+	);
+	rttTex->setPixelFormat(Ogre::PFG_RGBA8_UNORM);
+	rttTex->setTextureType(Ogre::TextureTypes::Type2D);
+	rttTex->setNumMipmaps(1u);
+	rttTex->setResolution(sz.d_width, sz.d_height);
+	
+	//Note all Rendertargets must be come Resident before use:
+	if(rttTex->getNextResidencyStatus() != Ogre::GpuResidency::Resident)
+	{
+		rttTex->_transitionTo(Ogre::GpuResidency::Resident, nullptr);
+		rttTex->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+	}
+	
+    d_textureGpuTarget = rttTex;
 
     const Rectf init_area(
         glm::vec2(0.0f, 0.0f),
         Sizef(
-            static_cast<float>(d_renderTarget->getWidth()),
-            static_cast<float>(d_renderTarget->getHeight())
+            static_cast<float>(d_textureGpuTarget->getWidth()),
+            static_cast<float>(d_textureGpuTarget->getHeight())
         )
     );
 
     setArea(init_area);
 
-    // delete viewport and reset ptr so a new one is generated.  This is
-    // required because we have changed d_renderTarget so need a new VP also.
-    OGRE_DELETE d_viewport;
-    d_viewport = 0;
-
-    // because Texture takes ownership, the act of setting the new ogre texture
-    // also ensures any previous ogre texture is released.
     d_CEGUITexture->setOgreTexture(rttTex, true);
 
     clear();
@@ -148,11 +139,139 @@ String OgreTextureTarget::generateTextureName()
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
-
 #ifdef __APPLE__
-
 template class CEGUI::OgreRenderTarget<CEGUI::RenderTarget>;
 template class CEGUI::OgreRenderTarget<CEGUI::TextureTarget>;
-
 #endif
 
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/TextureTarget.h"
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/PropertyHelper.h"
+
+#include <OgreTextureManager.h>
+#include <OgreHardwarePixelBuffer.h>
+#include <OgreRenderTexture.h>
+#include <OgreRenderSystem.h>
+#include <OgreViewport.h>
+
+
+// Start of CEGUI namespace section
+namespace CEGUI
+{
+	//----------------------------------------------------------------------------//
+	const float OgreTextureTarget::DEFAULT_SIZE = 128.0f;
+	std::uint32_t OgreTextureTarget::s_textureNumber = 0;
+
+	//----------------------------------------------------------------------------//
+	OgreTextureTarget::OgreTextureTarget(OgreRenderer& owner,
+		Ogre::RenderSystem& rs,
+		bool addStencilBuffer) :
+		OgreRenderTarget(owner, rs),
+		TextureTarget(addStencilBuffer),
+		d_CEGUITexture(0)
+	{
+		d_CEGUITexture = static_cast<OgreTexture*>(
+			&d_owner.createTexture(generateTextureName()));
+
+		// setup area and cause the initial texture to be generated.
+		declareRenderSize(Sizef(DEFAULT_SIZE, DEFAULT_SIZE));
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreTextureTarget::~OgreTextureTarget()
+	{
+		d_owner.destroyTexture(*d_CEGUITexture);
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreTextureTarget::isImageryCache() const
+	{
+		return true;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTextureTarget::clear()
+	{
+		if(!d_viewportValid)
+			updateViewport();
+
+		Ogre::Viewport* const saved_vp = d_renderSystem._getViewport();
+
+		d_renderSystem._setViewport(d_viewport);
+		d_renderSystem.clearFrameBuffer(Ogre::FBT_COLOUR,
+			Ogre::ColourValue(0, 0, 0, 0));
+
+#if OGRE_VERSION < 0x10800
+		if(saved_vp)
+			d_renderSystem._setViewport(saved_vp);
+#else
+		d_renderSystem._setViewport(saved_vp);
+#endif
+	}
+
+	//----------------------------------------------------------------------------//
+	Texture& OgreTextureTarget::getTexture() const
+	{
+		return *d_CEGUITexture;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreTextureTarget::declareRenderSize(const Sizef& sz)
+	{
+		// exit if current size is enough
+		if((d_area.getWidth() >= sz.d_width) && (d_area.getHeight() >= sz.d_height))
+			return;
+
+		Ogre::TexturePtr rttTex = Ogre::TextureManager::getSingleton().createManual(OgreTexture::getUniqueName(),
+			Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+			Ogre::TEX_TYPE_2D,
+			static_cast<Ogre::uint>(sz.d_width),
+			static_cast<Ogre::uint>(sz.d_height),
+			1,
+			0,
+			Ogre::PF_A8R8G8B8,
+			Ogre::TU_RENDERTARGET);
+
+		d_renderTarget = rttTex->getBuffer()->getRenderTarget();
+
+		const Rectf init_area(
+			glm::vec2(0.0f, 0.0f),
+			Sizef(
+				static_cast<float>(d_renderTarget->getWidth()),
+				static_cast<float>(d_renderTarget->getHeight())
+			)
+		);
+
+		setArea(init_area);
+
+		// delete viewport and reset ptr so a new one is generated.  This is
+		// required because we have changed d_renderTarget so need a new VP also.
+		OGRE_DELETE d_viewport;
+		d_viewport = 0;
+
+		// because Texture takes ownership, the act of setting the new ogre texture
+		// also ensures any previous ogre texture is released.
+		d_CEGUITexture->setOgreTexture(rttTex, true);
+
+		clear();
+	}
+
+	//----------------------------------------------------------------------------//
+	String OgreTextureTarget::generateTextureName()
+	{
+		String tmp("_ogre_tt_tex_");
+		tmp.append(PropertyHelper<std::uint32_t>::toString(s_textureNumber++));
+
+		return tmp;
+	}
+
+	//----------------------------------------------------------------------------//
+
+} // End of  CEGUI namespace section
+
+#ifdef __APPLE__
+template class CEGUI::OgreRenderTarget<CEGUI::RenderTarget>;
+template class CEGUI::OgreRenderTarget<CEGUI::TextureTarget>;
+#endif
+#endif	//CEGUI_OGRE_NEXT

--- a/cegui/src/RendererModules/Ogre/WindowTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/WindowTarget.cpp
@@ -25,18 +25,15 @@
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
 #include "CEGUI/RendererModules/Ogre/WindowTarget.h"
-
-#include <OgreRenderTarget.h>
+#ifdef CEGUI_OGRE_NEXT
+#include <OgreTextureGpu.h>
 #include <OgreViewport.h>
 
 // Start of CEGUI namespace section
 namespace CEGUI
 {
 //----------------------------------------------------------------------------//
-OgreWindowTarget::OgreWindowTarget(OgreRenderer& owner,
-                                   Ogre::RenderSystem& rs,
-                                   Ogre::RenderTarget& target) :
-    OgreRenderTarget(owner, rs)
+OgreWindowTarget::OgreWindowTarget(OgreRenderer& owner, Ogre::RenderSystem& rs, Ogre::Window* target) : OgreRenderTarget(owner, rs, false)
 {
     initRenderTarget(target);
 }
@@ -47,13 +44,8 @@ OgreWindowTarget::~OgreWindowTarget()
 }
 
 //----------------------------------------------------------------------------//
-void OgreWindowTarget::setOgreRenderTarget(Ogre::RenderTarget& target)
+void OgreWindowTarget::setOgreRenderTarget(Ogre::Window* target)
 {
-    // cleanup viewport since it's RT dependent.
-    OGRE_DELETE d_viewport;
-    d_viewport = 0;
-    d_viewportValid = false;
-
     initRenderTarget(target);
 }
 
@@ -64,13 +56,13 @@ bool OgreWindowTarget::isImageryCache() const
 }
 
 //----------------------------------------------------------------------------//
-void OgreWindowTarget::initRenderTarget(Ogre::RenderTarget& target)
+void OgreWindowTarget::initRenderTarget(Ogre::Window* target)
 {
-    d_renderTarget = &target;
+    d_textureGpuTarget = target->getTexture();
 
     Rectf init_area(glm::vec2(0.0f, 0.0f),
-                    Sizef(static_cast<float>(d_renderTarget->getWidth()), 
-                          static_cast<float>(d_renderTarget->getHeight())) );
+                    Sizef(static_cast<float>(d_textureGpuTarget->getWidth()),
+                          static_cast<float>(d_textureGpuTarget->getHeight())) );
 
     setArea(init_area);
 }
@@ -78,5 +70,60 @@ void OgreWindowTarget::initRenderTarget(Ogre::RenderTarget& target)
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
+#else	//CEGUI_OGRE_NEXT
+#include "CEGUI/RendererModules/Ogre/WindowTarget.h"
 
+#include <OgreRenderTarget.h>
+#include <OgreViewport.h>
+
+ // Start of CEGUI namespace section
+namespace CEGUI
+{
+	//----------------------------------------------------------------------------//
+	OgreWindowTarget::OgreWindowTarget(OgreRenderer& owner,
+		Ogre::RenderSystem& rs,
+		Ogre::RenderTarget& target) :
+		OgreRenderTarget(owner, rs)
+	{
+		initRenderTarget(target);
+	}
+
+	//----------------------------------------------------------------------------//
+	OgreWindowTarget::~OgreWindowTarget()
+	{
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreWindowTarget::setOgreRenderTarget(Ogre::RenderTarget& target)
+	{
+		// cleanup viewport since it's RT dependent.
+		OGRE_DELETE d_viewport;
+		d_viewport = 0;
+		d_viewportValid = false;
+
+		initRenderTarget(target);
+	}
+
+	//----------------------------------------------------------------------------//
+	bool OgreWindowTarget::isImageryCache() const
+	{
+		return false;
+	}
+
+	//----------------------------------------------------------------------------//
+	void OgreWindowTarget::initRenderTarget(Ogre::RenderTarget& target)
+	{
+		d_renderTarget = &target;
+
+		Rectf init_area(glm::vec2(0.0f, 0.0f),
+			Sizef(static_cast<float>(d_renderTarget->getWidth()),
+				static_cast<float>(d_renderTarget->getHeight())));
+
+		setArea(init_area);
+	}
+
+	//----------------------------------------------------------------------------//
+
+} // End of  CEGUI namespace section
+#endif	//CEGUI_OGRE_NEXT
 


### PR DESCRIPTION
Added support for Ogre 2.3. (It was not tested but should also work for Ogre 2.2). Because of the large amount of changes requried to port from Ogre 2.1, the define "CEGUI_OGRE_NEXT" was used to enable the updated code and when not defined, the old code for "2.1 and lower" is enabled . "CEGUI_OGRE_NEXT" is automatically set by dedecting the used Ogre version. This means most files now contain code for "2.1 or lower" and "2.2 or higher".