### PR TITLE
port to Ogre 2.3

### DIFF
--- a/cegui/include/CEGUI/RendererModules/Ogre/GeometryBuffer.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/GeometryBuffer.h
@@ -34,7 +34,6 @@
 
 #include <OgreColourValue.h>
 #include <OgreRenderOperation.h>
-#include <OgreTexture.h>
 #include <OgreMatrix4.h>
 
 #ifdef CEGUI_USE_OGRE_HLMS

--- a/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget2.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget2.h
@@ -1,0 +1,98 @@
+/***********************************************************************
+    created:    2022-01-30 (rewrite OgreRenderTarget for Ogre >= 2.2)
+    author:     Robert Paciorek
+*************************************************************************/
+/***************************************************************************
+ *   Copyright (C) 2004 - 2011 Paul D Turner & The CEGUI Development Team
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining
+ *   a copy of this software and associated documentation files (the
+ *   "Software"), to deal in the Software without restriction, including
+ *   without limitation the rights to use, copy, modify, merge, publish,
+ *   distribute, sublicense, and/or sell copies of the Software, and to
+ *   permit persons to whom the Software is furnished to do so, subject to
+ *   the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be
+ *   included in all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *   OTHER DEALINGS IN THE SOFTWARE.
+ ***************************************************************************/
+#ifndef _CEGUIOgreRenderTarget_h_
+#define _CEGUIOgreRenderTarget_h_
+
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#include "CEGUI/RenderTarget.h"
+#include "CEGUI/TextureTarget.h"
+#include "CEGUI/Rectf.h"
+#include <OgreMatrix4.h>
+
+namespace Ogre {
+    class RenderPassDescriptor;
+}
+
+namespace CEGUI
+{
+class OGRE_GUIRENDERER_API OgreRenderTextureTarget : virtual public RenderTarget, public TextureTarget
+{
+public:
+    //! Destructor
+    virtual ~OgreRenderTextureTarget();
+
+    // implement parts of CEGUI::RenderTarget interface:
+
+    void activate();
+    void deactivate();
+
+    void draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask = DrawModeMaskAll);
+    void draw(const RenderQueue& queue, std::uint32_t drawModeMask = DrawModeMaskAll);
+
+    void setArea(const Rectf& area);
+    bool isImageryCache() const;
+
+    void unprojectPoint(const GeometryBuffer& buff, const glm::vec2& p_in, glm::vec2& p_out) const;
+
+    OgreRenderer& getOwner();
+
+    // implement CEGUI::TextureTarget interface:
+
+    void clear();
+    Texture& getTexture() const;
+    void declareRenderSize(const Sizef& sz);
+
+protected:
+    static std::uint32_t s_textureNumber;
+
+    OgreTexture*                d_texture;
+    OgreRenderer&               d_owner;
+
+    Ogre::RenderSystem*         d_renderSystem;
+    Ogre::RenderPassDescriptor* d_renderPassDescriptor;
+    bool                        d_isImageryCache;
+    Ogre::Vector4               d_viewportSize;
+    Ogre::Vector4               d_viewportScissors;
+    bool                        d_needClear;
+
+    friend class OgreRenderer;
+
+    OgreRenderTextureTarget(
+        OgreRenderer& owner, Ogre::RenderSystem* renderSystem, Ogre::TextureGpu* texture = 0,
+        bool addStencilBuffer = false, bool takeOwnership = false, bool isImageryCache = true
+    );
+
+    void setOgreTexture(Ogre::TextureGpu*, bool takeOwnership = false);
+    void setArea(float width, float height);
+
+    void createRenderPassDescriptor();
+    void updateMatrix() const;
+    String generateTextureName();
+};
+
+} // End of  CEGUI namespace section
+#endif  // end of guard _CEGUIOgreRenderTarget_h_

--- a/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget2.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/RenderTarget2.h
@@ -74,10 +74,9 @@ protected:
 
     Ogre::RenderSystem*         d_renderSystem;
     Ogre::RenderPassDescriptor* d_renderPassDescriptor;
-    bool                        d_isImageryCache;
     Ogre::Vector4               d_viewportSize;
-    Ogre::Vector4               d_viewportScissors;
-    bool                        d_needClear;
+    bool                        d_isImageryCache;
+    char                        d_needClear;
 
     friend class OgreRenderer;
 
@@ -91,6 +90,7 @@ protected:
 
     void createRenderPassDescriptor();
     void updateMatrix() const;
+    void manageClear();
     String generateTextureName();
 };
 

--- a/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
@@ -63,6 +63,10 @@
 #include <OgreHlmsSamplerblock.h>
 #endif
 
+#if (CEGUI_OGRE_VERSION >= ((2 << 16) | (1 << 9) | 0))
+#define CEGUI_USE_OGRE_TEXTURE_GPU
+#endif
+
 namespace Ogre
 {
 class Root;
@@ -100,6 +104,7 @@ class OgreTexture;
 class OgreResourceProvider;
 class OgreImageCodec;
 class OgreWindowTarget;
+class OgreRenderTextureTarget;
 struct OgreRenderer_impl;
 
 //! CEGUI::Renderer implementation for the Ogre engine.
@@ -157,8 +162,13 @@ public:
     \return
         Reference to the CEGUI::OgreRenderer object that was created.
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    static OgreRenderer& bootstrapSystem(Ogre::Window* target,
+                                         const int abi = CEGUI_VERSION_ABI);
+#else
     static OgreRenderer& bootstrapSystem(Ogre::RenderTarget& target,
                                          const int abi = CEGUI_VERSION_ABI);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     /*!
     \brief
@@ -195,15 +205,25 @@ public:
         Create an OgreRenderer object that uses the specified Ogre::RenderTarget
         as the default output surface.
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    static OgreRenderer& create(Ogre::Window* target,
+                                const int abi = CEGUI_VERSION_ABI);
+#else
     static OgreRenderer& create(Ogre::RenderTarget& target,
                                 const int abi = CEGUI_VERSION_ABI);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     /*!
       \brief
       Creates a new renderer that can be used to create a context on a new Ogre window
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    static OgreRenderer& registerWindow(OgreRenderer& main_window,
+        Ogre::Window* new_window);
+#else
     static OgreRenderer& registerWindow(OgreRenderer& main_window,
         Ogre::RenderTarget &new_window);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     //! destroy an OgreRenderer object.
     static void destroy(OgreRenderer& renderer);
@@ -230,8 +250,11 @@ public:
     //! Function to initialize required Ogre::Compositor2 workspaces
     static void createOgreCompositorResources();
 
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+#else
     //! Function to update the workspace render target
     void updateWorkspaceRenderTarget(Ogre::RenderTarget& target);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 #endif // CEGUI_USE_OGRE_COMPOSITOR2
 
@@ -258,8 +281,13 @@ public:
         - false if ownership of \a tex remains with the client app, and so
         no attempt will be made to destroy \a tex when the Texture is destroyed.
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    Texture& createTexture(const String& name, Ogre::TextureGpu* tex,
+                           bool take_ownership = false);
+#else
     Texture& createTexture(const String& name, Ogre::TexturePtr& tex,
                            bool take_ownership = false);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     //! set the render states for the specified BlendMode.
     void setupRenderingBlendMode(const BlendMode mode,
@@ -342,7 +370,11 @@ public:
 
     \param target Sets the target for rendering required by PSO Cache
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    void initialiseRenderStateSettings(OgreRenderTextureTarget* target);
+#else
     void initialiseRenderStateSettings(Ogre::RenderTarget* target);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 #else
     /*!
         \brief
@@ -364,7 +396,11 @@ public:
         Reference to the Ogre::RenderTarget object that is to be used as the
         target for output from the default GUIContext.
     */
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    void setDefaultRootRenderTarget(Ogre::Window* target);
+#else
     void setDefaultRootRenderTarget(Ogre::RenderTarget& target);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     //! \brief Sets the correct BlendMode for rendering a GeometryBuffer
     void bindBlendMode(BlendMode blend);
@@ -418,6 +454,7 @@ public:
     virtual bool isTexCoordSystemFlipped() const;
 
     virtual Texture& createTexture(const String& name);
+    virtual Texture& createTexture(const String& name, bool notNullTexture);
     virtual Texture& createTexture(const String& name, const String& filename,
         const String& resourceGroup);
     virtual Texture& createTexture(const String& name, const Sizef& size);
@@ -461,7 +498,11 @@ protected:
     //! default constructor.
     OgreRenderer();
     //! constructor takin the Ogre::RenderTarget to use as the default root.
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    OgreRenderer(Ogre::Window* target);
+#else
     OgreRenderer(Ogre::RenderTarget& target);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
     //! destructor.
     virtual ~OgreRenderer();
 
@@ -475,7 +516,11 @@ protected:
     static void logTextureDestruction(const String& name);
 
     //! common parts of constructor
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    void constructor_impl(Ogre::Window* target);
+#else
     void constructor_impl(Ogre::RenderTarget& target);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
     //! Helper that switches off shader-usage
     void switchShaderUsageOff();
     //! helper that creates and sets up shaders

--- a/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
@@ -372,6 +372,8 @@ public:
     */
 #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
     void initialiseRenderStateSettings(OgreRenderTextureTarget* target);
+    void startWithClippingRegion(const Rectf& clippingRegion);
+    void startWithoutClippingRegion();
 #else
     void initialiseRenderStateSettings(Ogre::RenderTarget* target);
 #endif // CEGUI_USE_OGRE_TEXTURE_GPU

--- a/cegui/include/CEGUI/RendererModules/Ogre/Texture.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/Texture.h
@@ -29,8 +29,12 @@
 
 #include "../../Texture.h"
 #include "CEGUI/RendererModules/Ogre/Renderer.h"
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+#include <OgreTextureGpu.h>
+#else
 #include <OgreTexture.h>
 #include <OgreSharedPtr.h>
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 // Start of CEGUI namespace section
 namespace CEGUI
@@ -39,10 +43,17 @@ namespace CEGUI
 class OGRE_GUIRENDERER_API OgreTexture : public Texture
 {
 public:
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    //! Set the underlying Ogre texture.
+    void setOgreTexture(Ogre::TextureGpu* texture, bool take_ownership = false);
+    //! Return Ogre::TexturePtr for the underlying Ogre texture.
+    Ogre::TextureGpu* getOgreTexture() const;
+    #else
     //! Set the underlying Ogre texture.
     void setOgreTexture(Ogre::TexturePtr texture, bool take_ownership = false);
     //! Return Ogre::TexturePtr for the underlying Ogre texture.
     Ogre::TexturePtr getOgreTexture() const;
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     //! return a Ogre::string containing a unique name.
     static Ogre::String getUniqueName();
@@ -58,38 +69,63 @@ public:
     void blitFromMemory(const void* sourceData, const Rectf& area);
     void blitToMemory(void* targetData);
     bool isPixelFormatSupported(const PixelFormat fmt) const;
+    bool textureIsLinked() const;
 
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    //! convert Ogre::PixelFormatGpu to equivalent CEGUI::Texture::PixelFormat
+    static Texture::PixelFormat fromOgrePixelFormat(const Ogre::PixelFormatGpu fmt);
+    //! convert CEGUI::Texture::PixelFormat to equivalent Ogre::PixelFormatGpu
+    static Ogre::PixelFormatGpu toOgrePixelFormat(const Texture::PixelFormat fmt);
+    #else
     //! convert Ogre::PixelFormat to equivalent CEGUI::Texture::PixelFormat
     static Texture::PixelFormat fromOgrePixelFormat(const Ogre::PixelFormat fmt);
     //! convert CEGUI::Texture::PixelFormat to equivalent Ogre::PixelFormat
     static Ogre::PixelFormat toOgrePixelFormat(const Texture::PixelFormat fmt);
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 protected:
     // we all need a little help from out friends ;)
-    friend Texture& OgreRenderer::createTexture(const String&);
+    friend Texture& OgreRenderer::createTexture(const String&, bool);
     friend Texture& OgreRenderer::createTexture(const String&, const String&,
                                                 const String&);
     friend Texture& OgreRenderer::createTexture(const String&, const Sizef&);
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    friend Texture& OgreRenderer::createTexture(const String&, Ogre::TextureGpu*,
+                                                bool);
+    #else
     friend Texture& OgreRenderer::createTexture(const String&, Ogre::TexturePtr&,
                                                 bool);
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
     friend void OgreRenderer::destroyTexture(Texture&);
     friend void OgreRenderer::destroyTexture(const String&);
 
     //! standard constructor
-    OgreTexture(const String& name);
+    OgreTexture(const String& name, bool notNullTexture = true);
     //! construct texture via an image file.
     OgreTexture(const String& name, const String& filename,
                 const String& resourceGroup);
     //! construct texture with a specified initial size.
     OgreTexture(const String& name, const Sizef& sz);
     //! construct texture from existing Ogre texture.
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    OgreTexture(const String& name, Ogre::TextureGpu* tex, bool take_ownership);
+    #else
     OgreTexture(const String& name, Ogre::TexturePtr& tex, bool take_ownership);
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 
     //! destructor.
     virtual ~OgreTexture();
     //! construct an empty texture
-    void createEmptyOgreTexture(PixelFormat pixel_format);
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    void createOgreTexture(
+        Ogre::PixelFormatGpu pixel_format = Ogre::PFG_RGBA8_UNORM,
+        std::uint32_t width = 1, std::uint32_t height = 1,
+        Ogre::GpuPageOutStrategy::GpuPageOutStrategy pageOutStrategy = Ogre::GpuPageOutStrategy::Discard
+    );
+    #else
+    void createEmptyOgreTexture(PixelFormat pixel_format = Texture::PixelFormat::Rgba);
+    #endif
     //! release the underlying Ogre texture.
     void freeOgreTexture();
     //! updates cached scale value used to map pixels to texture co-ords.
@@ -98,7 +134,11 @@ protected:
     //! Counter used to provide unique texture names.
     static std::uint32_t d_textureNumber;
     //!< The underlying Ogre texture.
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    Ogre::TextureGpu* d_texture;
+    #else
     Ogre::TexturePtr d_texture;
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
     //! specifies whether d_texture was created externally (not owned by us).
     bool d_isLinked;
     //! Size of the texture.

--- a/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
+++ b/cegui/src/RendererModules/Ogre/GeometryBuffer.cpp
@@ -91,30 +91,30 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
         return;
 
 #ifdef CEGUI_USE_OGRE_HLMS
+    #ifndef CEGUI_USE_OGRE_TEXTURE_GPU
     //Ogre::Viewport* previousViewport = d_renderSystem._getViewport();
     //Ogre::Viewport* currentViewport = d_owner.getOgreRenderTarget()->getViewport(0);
     
     // If this viewport approach fails we'll probably need to mess with the
     // set hlms macro block in the Renderer
-    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
-    Ogre::Viewport* currentViewport = &d_renderSystem._getCurrentRenderViewport();
-    #else
     Ogre::Viewport* currentViewport = d_renderSystem._getViewport();
-    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     Rectf previousClipRect;
     previousClipRect.left(currentViewport->getScissorLeft());
     previousClipRect.top(currentViewport->getScissorTop());
     previousClipRect.right(currentViewport->getScissorWidth());
     previousClipRect.bottom(currentViewport->getScissorHeight());
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 #endif //CEGUI_USE_OGRE_HLMS
     
     // setup clip region
     if (d_clippingActive)
     {
     #ifdef CEGUI_USE_OGRE_HLMS
+        #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+        d_owner.startWithClippingRegion(d_preparedClippingRegion);
+        #else
         setScissorRects(currentViewport);
-        #ifndef CEGUI_USE_OGRE_TEXTURE_GPU
 		// clear and re-set viewport to have ogre apply the actual scissor settings
 		d_renderSystem._setViewport(NULL);
 		d_renderSystem._setViewport(currentViewport);
@@ -123,6 +123,10 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
         setScissorRects();
     #endif //CEGUI_USE_OGRE_HLMS
     }
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    else
+	    d_owner.startWithoutClippingRegion();
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     // Update the matrix
     updateMatrix();
@@ -179,11 +183,11 @@ void OgreGeometryBuffer::draw(std::uint32_t drawModeMask) const
     if (d_clippingActive)
     {
     #ifdef CEGUI_USE_OGRE_HLMS
+        #ifndef CEGUI_USE_OGRE_TEXTURE_GPU
         currentViewport->setScissors(previousClipRect.left(), previousClipRect.top(),
             previousClipRect.right(), previousClipRect.bottom());
         // Restore viewport? d_renderSystem._setViewport(previousViewport);
 		
-        #ifndef CEGUI_USE_OGRE_TEXTURE_GPU
 		// clear and re-set viewport to have ogre apply the previous scissor settings
 		d_renderSystem._setViewport(NULL);
 		d_renderSystem._setViewport(currentViewport);

--- a/cegui/src/RendererModules/Ogre/RenderTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget.cpp
@@ -24,6 +24,10 @@
  *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
+
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#ifndef CEGUI_USE_OGRE_TEXTURE_GPU
+
 #include "CEGUI/RendererModules/Ogre/RenderTarget.h"
 #include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
 #include "CEGUI/Exceptions.h"
@@ -232,3 +236,5 @@ void OgreRenderTarget::setArea(const Rectf& area)
 //----------------------------------------------------------------------------//
 
 } // End of  CEGUI namespace section
+
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU

--- a/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
@@ -1,0 +1,325 @@
+/***********************************************************************
+    created:    2022-01-30 (rewrite OgreRenderTarget for Ogre >= 2.2)
+    author:     Robert Paciorek
+*************************************************************************/
+/***************************************************************************
+ *   Copyright (C) 2004 - 2011 Paul D Turner & The CEGUI Development Team
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining
+ *   a copy of this software and associated documentation files (the
+ *   "Software"), to deal in the Software without restriction, including
+ *   without limitation the rights to use, copy, modify, merge, publish,
+ *   distribute, sublicense, and/or sell copies of the Software, and to
+ *   permit persons to whom the Software is furnished to do so, subject to
+ *   the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be
+ *   included in all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *   OTHER DEALINGS IN THE SOFTWARE.
+ ***************************************************************************/
+
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+
+#include "CEGUI/RendererModules/Ogre/RenderTarget2.h"
+#include "CEGUI/RendererModules/Ogre/GeometryBuffer.h"
+#include "CEGUI/RendererModules/Ogre/Texture.h"
+#include "CEGUI/RenderQueue.h"
+#include "CEGUI/PropertyHelper.h"
+
+#include <OgreRenderSystem.h>
+#include <OgreRenderPassDescriptor.h>
+#include <OgreColourValue.h>
+#include <OgreWindow.h>
+#include <OgreTextureGpuManager.h>
+#include <OgreResourceGroupManager.h>
+
+namespace CEGUI
+{
+
+std::uint32_t OgreRenderTextureTarget::s_textureNumber = 0;
+
+OgreRenderTextureTarget::OgreRenderTextureTarget(
+    OgreRenderer& owner, Ogre::RenderSystem* renderSystem, Ogre::TextureGpu* texture,
+    bool addStencilBuffer, bool takeOwnership, bool isImageryCache
+) :
+    TextureTarget(addStencilBuffer),
+    d_owner(owner),
+    d_renderSystem(renderSystem),
+    d_renderPassDescriptor(0),
+    d_isImageryCache(isImageryCache),
+    d_viewportScissors(0, 0, 1, 1)
+{
+    if (texture == NULL) {
+        d_texture = static_cast<OgreTexture*>(
+            &owner.createTexture(
+                generateTextureName(), false
+            )
+        );
+        setArea(0, 0); // this is null texture
+    } else {
+        d_texture = static_cast<OgreTexture*>(
+            &owner.createTexture(
+                generateTextureName(), texture, takeOwnership)
+        );
+        setArea(
+            d_texture->getOgreTexture()->getWidth(),
+            d_texture->getOgreTexture()->getHeight()
+        );
+        createRenderPassDescriptor();
+    }
+}
+
+OgreRenderTextureTarget::~OgreRenderTextureTarget() {
+    if (d_renderPassDescriptor) {
+        d_renderSystem->destroyRenderPassDescriptor( d_renderPassDescriptor );
+    }
+    d_owner.destroyTexture(*d_texture);
+}
+
+//----------------------------------------------------------------------------//
+
+void OgreRenderTextureTarget::setOgreTexture(Ogre::TextureGpu* texture, bool takeOwnership) {
+    d_texture->setOgreTexture(texture, takeOwnership);
+    setArea(
+        d_texture->getOgreTexture()->getWidth(),
+        d_texture->getOgreTexture()->getHeight()
+    );
+    createRenderPassDescriptor();
+}
+
+void OgreRenderTextureTarget::createRenderPassDescriptor() {
+    // Destroy old pass descriptor
+    if (d_renderPassDescriptor) {
+        d_renderSystem->destroyRenderPassDescriptor( d_renderPassDescriptor );
+    }
+
+    // Create a pass descriptor to specify what texture we want to render against.
+    d_renderPassDescriptor = d_renderSystem->createRenderPassDescriptor();
+    d_renderPassDescriptor->mColour[0].texture = d_texture->getOgreTexture();
+    d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
+    d_renderPassDescriptor->mColour[0].storeAction = Ogre::StoreAction::Store;
+    d_renderPassDescriptor->entriesModified( 1 );
+}
+
+void OgreRenderTextureTarget::declareRenderSize(const Sizef& sz)
+{
+    // exit if texture is linked
+    if (d_texture->textureIsLinked())
+        return;
+
+    // exit if current size is enough
+    if ((d_area.getWidth() >= sz.d_width) && (d_area.getHeight() >=sz.d_height))
+        return;
+
+    // The underlying texture is not sufficient for the requested size.
+    // We create a new RTT here based on the dimensions requested.
+
+    const Ogre::uint width = static_cast<Ogre::uint>(sz.d_width);
+    const Ogre::uint height = static_cast<Ogre::uint>(sz.d_height);
+
+    Ogre::TextureGpu* rttTex = d_renderSystem->getTextureGpuManager()->createTexture(
+            OgreTexture::getUniqueName(),
+            Ogre::GpuPageOutStrategy::Discard,
+            Ogre::TextureFlags::RenderToTexture,
+            Ogre::TextureTypes::Type2D,
+            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME
+    );
+
+    rttTex->setResolution(width, height, 1u);
+    rttTex->setNumMipmaps(1);
+    rttTex->setPixelFormat(Ogre::PFG_RGBA8_UNORM);
+
+    rttTex->_transitionTo(Ogre::GpuResidency::Resident, nullptr);
+    rttTex->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+    rttTex->notifyDataIsReady();
+
+    // because Texture takes ownership, the act of setting the new ogre texture
+    // also ensures any previous ogre texture is released.
+    d_texture->setOgreTexture(rttTex, true);
+
+    setArea(rttTex->getWidth(), rttTex->getHeight());
+    createRenderPassDescriptor();
+
+    // Since we changed the texture, request viewport to be cleared.
+    clear();
+}
+
+//----------------------------------------------------------------------------//
+
+void OgreRenderTextureTarget::setArea(float width, float height)
+{
+    const Rectf init_area(
+        glm::vec2(0.0f, 0.0f),
+        Sizef(width, height)
+    );
+    setArea(init_area);
+}
+
+void OgreRenderTextureTarget::setArea(const Rectf& area)
+{
+    Ogre::TextureGpu* tex = d_texture->getOgreTexture();
+    if (tex) {
+        d_viewportSize.x = area.left() / tex->getWidth();
+        d_viewportSize.y = area.top() / tex->getHeight();
+        d_viewportSize.z = area.getWidth() / tex->getWidth();
+        d_viewportSize.w = area.getHeight() / tex->getHeight();
+    }
+
+    RenderTarget::setArea(area);
+    updateMatrix();
+}
+
+//----------------------------------------------------------------------------//
+
+void OgreRenderTextureTarget::activate()
+{
+    if (d_needClear)
+        d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Clear;
+
+    d_owner.initialiseRenderStateSettings(this);
+
+    RenderTarget::activate();
+}
+
+void OgreRenderTextureTarget::deactivate()
+{
+    d_renderSystem->endRenderPassDescriptor();
+
+    if (d_needClear)
+    {
+        d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
+        d_needClear = false;
+    }
+
+    RenderTarget::deactivate();
+}
+
+//----------------------------------------------------------------------------//
+
+void OgreRenderTextureTarget::clear() {
+    d_needClear = true;
+}
+
+void OgreRenderTextureTarget::draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask)
+{
+    buffer.draw(drawModeMask);
+}
+
+void OgreRenderTextureTarget::draw(const RenderQueue& queue, std::uint32_t drawModeMask)
+{
+    queue.draw(drawModeMask);
+}
+
+//----------------------------------------------------------------------------//
+
+Texture& OgreRenderTextureTarget::getTexture() const {
+    return *d_texture;
+}
+
+bool OgreRenderTextureTarget::isImageryCache() const
+{
+    return d_isImageryCache;
+}
+
+OgreRenderer& OgreRenderTextureTarget::getOwner() {
+    return d_owner;
+}
+
+//----------------------------------------------------------------------------//
+
+void OgreRenderTextureTarget::updateMatrix() const
+{
+    if (d_owner.usesOpenGL())
+        RenderTarget::updateMatrix( RenderTarget::createViewProjMatrixForOpenGL() );
+    else if (d_owner.usesDirect3D())
+        RenderTarget::updateMatrix( RenderTarget::createViewProjMatrixForDirect3D() );
+    else
+        throw RendererException("An unsupported RenderSystem is being used by Ogre. Please contact the CEGUI team.");
+}
+
+void OgreRenderTextureTarget::unprojectPoint(const GeometryBuffer& buff,
+                                         const glm::vec2& p_in,
+                                         glm::vec2& p_out) const
+{
+    if (!RenderTarget::d_matrixValid)
+        updateMatrix();
+
+    const OgreGeometryBuffer& gb = static_cast<const OgreGeometryBuffer&>(buff);
+
+    const Ogre::Real midx = RenderTarget::d_area.getWidth() * 0.5f;
+    const Ogre::Real midy = RenderTarget::d_area.getHeight() * 0.5f;
+
+    // viewport matrix
+    const Ogre::Matrix4 vpmat(
+        midx,    0,    0,    RenderTarget::d_area.left() + midx,
+         0,    -midy,  0,    RenderTarget::d_area.top() + midy,
+         0,      0,    1,    0,
+         0,      0,    0,    1
+    );
+
+    // matrices used for projecting and unprojecting points
+
+    const Ogre::Matrix4 proj(OgreRenderer::glmToOgreMatrix(gb.getModelMatrix() * RenderTarget::d_matrix) * vpmat);
+    const Ogre::Matrix4 unproj(proj.inverse());
+
+    Ogre::Vector3 in;
+
+    // unproject the ends of the ray
+    in.x = midx;
+    in.y = midy;
+    in.z = -RenderTarget::d_viewDistance;
+    const Ogre::Vector3 r1(unproj * in);
+    in.x = p_in.x;
+    in.y = p_in.y;
+    in.z = 0;
+    // calculate vector of picking ray
+    const Ogre::Vector3 rv(r1 - unproj * in);
+
+    // project points to orientate them with GeometryBuffer plane
+    in.x = 0.0;
+    in.y = 0.0;
+    const Ogre::Vector3 p1(proj * in);
+    in.x = 1.0;
+    in.y = 0.0;
+    const Ogre::Vector3 p2(proj * in);
+    in.x = 0.0;
+    in.y = 1.0;
+    const Ogre::Vector3 p3(proj * in);
+
+    // calculate the plane normal
+    const Ogre::Vector3 pn((p2 - p1).crossProduct(p3 - p1));
+    // calculate distance from origin
+    const Ogre::Real plen = pn.length();
+    const Ogre::Real dist = -(p1.x * (pn.x / plen) +
+                              p1.y * (pn.y / plen) +
+                              p1.z * (pn.z / plen));
+
+    // calculate intersection of ray and plane
+    const Ogre::Real pn_dot_rv = pn.dotProduct(rv);
+    const Ogre::Real tmp = pn_dot_rv != 0.0 ?
+                            (pn.dotProduct(r1) + dist) / pn_dot_rv :
+                            0.0f;
+
+    p_out.x = static_cast<float>(r1.x - rv.x * tmp);
+    p_out.y = static_cast<float>(r1.y - rv.y * tmp);
+}
+
+String OgreRenderTextureTarget::generateTextureName()
+{
+    String tmp("_ogre_tt_tex_");
+    tmp.append(PropertyHelper<std::uint32_t>::toString(s_textureNumber++));
+
+    return tmp;
+}
+
+}
+
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU

--- a/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
@@ -54,8 +54,7 @@ OgreRenderTextureTarget::OgreRenderTextureTarget(
     d_owner(owner),
     d_renderSystem(renderSystem),
     d_renderPassDescriptor(0),
-    d_isImageryCache(isImageryCache),
-    d_viewportScissors(0, 0, 1, 1)
+    d_isImageryCache(isImageryCache)
 {
     if (texture == NULL) {
         d_texture = static_cast<OgreTexture*>(
@@ -186,12 +185,6 @@ void OgreRenderTextureTarget::setArea(const Rectf& area)
 
 void OgreRenderTextureTarget::activate()
 {
-    if (d_needClear)
-    {
-        d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Clear;
-        d_renderPassDescriptor->entriesModified( 1 );
-    }
-
     d_owner.initialiseRenderStateSettings(this);
 
     RenderTarget::activate();
@@ -201,20 +194,27 @@ void OgreRenderTextureTarget::deactivate()
 {
     d_renderSystem->endRenderPassDescriptor();
 
-    if (d_needClear)
-    {
-        d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
-        d_renderPassDescriptor->entriesModified( 1 );
-        d_needClear = false;
-    }
-
     RenderTarget::deactivate();
 }
 
 //----------------------------------------------------------------------------//
 
+void OgreRenderTextureTarget::manageClear() {
+    switch(d_needClear) {
+        case 1:
+            d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Clear;
+            d_renderPassDescriptor->entriesModified( 1 );
+            d_needClear = -1;
+            break;
+        case -1:
+            d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
+            d_renderPassDescriptor->entriesModified( 1 );
+            d_needClear = 0;
+            break;
+    }
+}
 void OgreRenderTextureTarget::clear() {
-    d_needClear = true;
+    d_needClear = 1;
 }
 
 void OgreRenderTextureTarget::draw(const GeometryBuffer& buffer, std::uint32_t drawModeMask)

--- a/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
@@ -138,9 +138,13 @@ void OgreRenderTextureTarget::declareRenderSize(const Sizef& sz)
     rttTex->setNumMipmaps(1);
     rttTex->setPixelFormat(Ogre::PFG_RGBA8_UNORM);
 
-    rttTex->_transitionTo(Ogre::GpuResidency::Resident, nullptr);
-    rttTex->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
-    rttTex->notifyDataIsReady();
+    if (rttTex->getNextResidencyStatus() != Ogre::GpuResidency::Resident) {
+        rttTex->_transitionTo(Ogre::GpuResidency::Resident, nullptr);
+        rttTex->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+        #if OGRE_VERSION_MINOR == 2
+        rttTex->notifyDataIsReady();
+        #endif
+    }
 
     // because Texture takes ownership, the act of setting the new ogre texture
     // also ensures any previous ogre texture is released.

--- a/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
@@ -106,6 +106,7 @@ void OgreRenderTextureTarget::createRenderPassDescriptor() {
     d_renderPassDescriptor->mColour[0].texture = d_texture->getOgreTexture();
     d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
     d_renderPassDescriptor->mColour[0].storeAction = Ogre::StoreAction::Store;
+    d_renderPassDescriptor->mColour[0].clearColour = Ogre::ColourValue(0.0, 0.0, 0.0, 0.0);
     d_renderPassDescriptor->entriesModified( 1 );
 }
 

--- a/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
+++ b/cegui/src/RendererModules/Ogre/RenderTarget2.cpp
@@ -182,7 +182,10 @@ void OgreRenderTextureTarget::setArea(const Rectf& area)
 void OgreRenderTextureTarget::activate()
 {
     if (d_needClear)
+    {
         d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Clear;
+        d_renderPassDescriptor->entriesModified( 1 );
+    }
 
     d_owner.initialiseRenderStateSettings(this);
 
@@ -196,6 +199,7 @@ void OgreRenderTextureTarget::deactivate()
     if (d_needClear)
     {
         d_renderPassDescriptor->mColour[0].loadAction = Ogre::LoadAction::Load;
+        d_renderPassDescriptor->entriesModified( 1 );
         d_needClear = false;
     }
 

--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -809,7 +809,11 @@ OgreRenderer::~OgreRenderer()
 {
 #ifdef CEGUI_USE_OGRE_COMPOSITOR2
     // Remove the listener and then delete the scene
-    d_pimpl->d_workspace->setListener(0);
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    d_pimpl->d_workspace->addListener(d_pimpl->d_frameListener);
+    #else
+    d_pimpl->d_workspace->removeListener(d_pimpl->d_frameListener);
+    #endif
 
     d_pimpl->d_ogreRoot->destroySceneManager(d_pimpl->d_dummyScene);
 
@@ -832,12 +836,13 @@ OgreRenderer::~OgreRenderer()
     delete d_pimpl->d_frameListener;
 #endif
 
+    delete d_pimpl->d_defaultTarget;
+
     destroyAllGeometryBuffers();
     destroyAllTextureTargets();
     destroyAllTextures();
     clearVertexBufferPool();
 
-    delete d_pimpl->d_defaultTarget;
     delete d_pimpl;
 }
 

--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -333,18 +333,7 @@ void OgreRenderer::configureCeguiWindowForRTT(CEGUI::Window* window, const std::
     image->setTexture(&rendererTexture);
 
     //Flipping is necessary due to differences between renderers regarding top or bottom being the origin
-#ifdef CEGUI_USE_OGRE_TEXTURE_GPU 
-    bool isTextureTargetVerticallyFlipped = ogreTexture->requiresTextureFlipping();
-#else
-    bool isTextureTargetVerticallyFlipped = d_pimpl->d_renderSystem->_getViewport()->getTarget()->requiresTextureFlipping();
-#endif
-    CEGUI::Rectf imageArea;
-
-    if(isTextureTargetVerticallyFlipped)
-        imageArea = CEGUI::Rectf(0.0f, textureHeight, textureWidth, 0.0f);
-    else
-        imageArea = CEGUI::Rectf(0.0f, 0.0f, textureWidth, textureHeight);
-
+    CEGUI::Rectf imageArea = CEGUI::Rectf(0.0f, 0.0f, textureWidth, textureHeight);
     image->setImageArea(imageArea);
     image->setAutoScaled(CEGUI::AutoScaledMode::Disabled);
 

--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -446,7 +446,7 @@ void OgreRenderer::createOgreCompositorResources()
     // Only clear depth and stencil since we are rendering on top
     // of an existing image
     #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
-    clearpass->setBuffersToClear(Ogre::FBT_DEPTH | Ogre::FBT_STENCIL);
+    clearpass->setBuffersToClear(Ogre::RenderPassDescriptor::Depth | Ogre::RenderPassDescriptor::Stencil);
     #else
     clearpass->mClearBufferFlags = Ogre::FBT_DEPTH | Ogre::FBT_STENCIL;
     #endif // CEGUI_USE_OGRE_TEXTURE_GPU

--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -1374,12 +1374,46 @@ void OgreRenderer::initialiseRenderStateSettings(OgreRenderTextureTarget* target
 
     d_pimpl->d_hlmsCache->setRenderTarget( target->d_renderPassDescriptor );
 
+    d_activeRenderTarget = target;
+}
+void OgreRenderer::startWithClippingRegion(const Rectf& clippingRegion) {
+    OgreRenderTextureTarget* target = dynamic_cast<OgreRenderTextureTarget*>(d_activeRenderTarget);
+    Ogre::TextureGpu* targetTexture = target->d_texture->getOgreTexture();
+
+    int actualWidth = targetTexture->getWidth();
+    int actualHeight = targetTexture->getHeight();
+
+    Ogre::Vector4 scissors(
+        clippingRegion.left() / actualWidth,
+        clippingRegion.top() / actualHeight,
+        (clippingRegion.right() - clippingRegion.left()) / actualWidth,
+        (clippingRegion.bottom() - clippingRegion.top()) / actualHeight
+    );
+
+    target->manageClear();
+
     d_pimpl->d_renderSystem->beginRenderPassDescriptor(
         target->d_renderPassDescriptor,
-        target->d_texture->getOgreTexture(),
+        targetTexture,
         0,
         &target->d_viewportSize,
-        &target->d_viewportScissors,
+        &scissors,
+        1,
+        false,
+        false
+    );
+}
+void OgreRenderer::startWithoutClippingRegion() {
+    OgreRenderTextureTarget* target = dynamic_cast<OgreRenderTextureTarget*>(d_activeRenderTarget);
+    Ogre::TextureGpu* targetTexture = target->d_texture->getOgreTexture();
+
+    Ogre::Vector4 scissors(0, 0, 1, 1);
+    d_pimpl->d_renderSystem->beginRenderPassDescriptor(
+        target->d_renderPassDescriptor,
+        targetTexture,
+        0,
+        &target->d_viewportSize,
+        &scissors,
         1,
         false,
         false

--- a/cegui/src/RendererModules/Ogre/ResourceProvider.cpp
+++ b/cegui/src/RendererModules/Ogre/ResourceProvider.cpp
@@ -29,6 +29,7 @@
 #include "CEGUI/RendererModules/Ogre/ResourceProvider.h"
 #include "CEGUI/Exceptions.h"
 #include "CEGUI/RendererModules/Ogre/OgreMacros.h"
+#include "CEGUI/DataContainer.h"
 
 #include <OgreArchiveManager.h>
 #include <OgreResourceGroupManager.h>

--- a/cegui/src/RendererModules/Ogre/ShaderWrapper.cpp
+++ b/cegui/src/RendererModules/Ogre/ShaderWrapper.cpp
@@ -146,8 +146,15 @@ void OgreShaderWrapper::prepareForRendering(const ShaderParameterBindings*
             const CEGUI::OgreTexture* texture = static_cast<const
                 CEGUI::OgreTexture*>(parameterTexture->d_parameterValue);
 
-            Ogre::TexturePtr actual_texture = texture->getOgreTexture();
+            auto actual_texture = texture->getOgreTexture();
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+            if (!actual_texture)
+            {
+                throw RendererException("Ogre texture is null");
+            }
 
+            d_renderSystem._setTexture(0, actual_texture, false);
+#else
             if (OGRE_ISNULL(actual_texture))
             {
                 throw RendererException("Ogre texture ptr is empty");
@@ -158,6 +165,7 @@ void OgreShaderWrapper::prepareForRendering(const ShaderParameterBindings*
         #else
             d_renderSystem._setTexture(0, true, actual_texture);
         #endif //CEGUI_USE_OGRE_HLMS
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
             d_owner.initialiseTextureStates();
 

--- a/cegui/src/RendererModules/Ogre/Texture.cpp
+++ b/cegui/src/RendererModules/Ogre/Texture.cpp
@@ -87,6 +87,7 @@ std::uint32_t OgreTexture::d_textureNumber = 0;
 
 //----------------------------------------------------------------------------//
 OgreTexture::OgreTexture(const String& name, bool notNullTexture) :
+    d_texture(0),
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
@@ -100,6 +101,7 @@ OgreTexture::OgreTexture(const String& name, bool notNullTexture) :
 //----------------------------------------------------------------------------//
 OgreTexture::OgreTexture(const String& name, const String& filename,
                          const String& resourceGroup) :
+    d_texture(0),
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
@@ -111,6 +113,7 @@ OgreTexture::OgreTexture(const String& name, const String& filename,
 
 //----------------------------------------------------------------------------//
 OgreTexture::OgreTexture(const String& name, const Sizef& sz) :
+    d_texture(0),
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
@@ -175,6 +178,7 @@ OgreTexture::OgreTexture(const String& name, Ogre::TextureGpu* tex,
 OgreTexture::OgreTexture(const String& name, Ogre::TexturePtr& tex,
                          bool take_ownership) :
 #endif // CEGUI_USE_OGRE_TEXTURE_GPU
+    d_texture(0),
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),

--- a/cegui/src/RendererModules/Ogre/Texture.cpp
+++ b/cegui/src/RendererModules/Ogre/Texture.cpp
@@ -29,10 +29,21 @@
 #include "CEGUI/System.h"
 #include "CEGUI/RendererModules/Ogre/ImageCodec.h"
 #include "CEGUI/RendererModules/Ogre/OgreMacros.h"
+#include "CEGUI/RendererModules/Ogre/ResourceProvider.h"
+#include "CEGUI/DataContainer.h"
+#include "CEGUI/Rectf.h"
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+#include <OgreRoot.h>
+#include <OgreTextureGpuManager.h>
+#include <OgrePixelFormatGpuUtils.h>
+#include <OgreStagingTexture.h>
+#else
 #include <OgreTextureManager.h>
 #include <OgreHardwarePixelBuffer.h>
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 #include <cstdint>
+#include <sstream>
 
 // Start of CEGUI namespace section
 namespace CEGUI
@@ -75,14 +86,15 @@ static size_t calculateDataSize(const Sizef size, Texture::PixelFormat fmt)
 std::uint32_t OgreTexture::d_textureNumber = 0;
 
 //----------------------------------------------------------------------------//
-OgreTexture::OgreTexture(const String& name) :
+OgreTexture::OgreTexture(const String& name, bool notNullTexture) :
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
     d_texelScaling(0, 0),
     d_name(name)
 {
-    createEmptyOgreTexture(Texture::PixelFormat::Rgba);
+    if (notNullTexture)
+        createOgreTexture();
 }
 
 //----------------------------------------------------------------------------//
@@ -105,10 +117,44 @@ OgreTexture::OgreTexture(const String& name, const Sizef& sz) :
     d_texelScaling(0, 0),
     d_name(name)
 {
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    const Ogre::uint32 width = static_cast<Ogre::uint32>(sz.d_width);
+    const Ogre::uint32 height = static_cast<Ogre::uint32>(sz.d_height);
+
+    createOgreTexture(Ogre::PFG_RGBA8_UNORM, width, height);
+
+    // lets go ahead and allocate the memory buffer for this texture and make
+    // it resident on the GPU.  We do this so that later GPU blit operations
+    // can make some assumptions that the texture is resident & available for
+    // being mapped.  We can look at optimizing this later if need be.
+    size_t bytesPerRow = Ogre::PixelFormatGpuUtils::getBytesPerPixel( d_texture->getPixelFormat() ) * width;
+    void* data = OGRE_MALLOC_SIMD( bytesPerRow * height, Ogre::MEMCATEGORY_RENDERSYS );
+    memset( data, 0, bytesPerRow * height );
+
+    d_texture->_transitionTo( Ogre::GpuResidency::Resident, static_cast<Ogre::uint8*>( data ) );
+    d_texture->_setNextResidencyStatus( Ogre::GpuResidency::Resident );
+
+    Ogre::TextureGpuManager *textureMgr = Ogre::Root::getSingletonPtr()->getRenderSystem()->getTextureGpuManager();
+
+    Ogre::StagingTexture *stagingTexture = textureMgr->getStagingTexture(
+            width, height, 1u, 1u, d_texture->getPixelFormat() );
+
+    stagingTexture->startMapRegion();
+    Ogre::TextureBox box = stagingTexture->mapRegion( width, height, 1u, 1u, d_texture->getPixelFormat() );
+    box.copyFrom( data, width, height, bytesPerRow );
+    stagingTexture->stopMapRegion();
+
+    stagingTexture->upload( box, d_texture, 0, nullptr, nullptr, true );
+
+    textureMgr->removeStagingTexture( stagingTexture );
+    OGRE_FREE_SIMD(data, Ogre::MEMCATEGORY_RENDERSYS);
+    d_texture->notifyDataIsReady();
+#else
     d_texture = Ogre::TextureManager::getSingleton().createManual(
         getUniqueName(), "General", Ogre::TEX_TYPE_2D,
         sz.d_width, sz.d_height, 0,
         Ogre::PF_A8B8G8R8);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     // throw exception if no texture was able to be created
     if (OGRE_ISNULL(d_texture))
@@ -122,8 +168,13 @@ OgreTexture::OgreTexture(const String& name, const Sizef& sz) :
 }
 
 //----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+OgreTexture::OgreTexture(const String& name, Ogre::TextureGpu* tex,
+                         bool take_ownership) :
+#else
 OgreTexture::OgreTexture(const String& name, Ogre::TexturePtr& tex,
                          bool take_ownership) :
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
     d_isLinked(false),
     d_size(0, 0),
     d_dataSize(0, 0),
@@ -212,6 +263,64 @@ void OgreTexture::loadFromMemory(const void* buffer, const Sizef& buffer_size,
         throw InvalidRequestException(
             "Data was supplied in an unsupported pixel format.");
 
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    Ogre::PixelFormatGpu ogrePixelFormat = toOgrePixelFormat(pixel_format);
+
+    const std::uint32_t width = static_cast<std::uint32_t>(buffer_size.d_width);
+    const std::uint32_t height = static_cast<std::uint32_t>(buffer_size.d_height);
+
+    size_t bytesPerPixel = Ogre::PixelFormatGpuUtils::getBytesPerPixel(ogrePixelFormat);
+    size_t bytesPerRow = bytesPerPixel * width;
+    Ogre::TextureBox srcBox( width, height, 1u, 1u, bytesPerPixel, bytesPerRow, bytesPerRow * height );
+    srcBox.data = const_cast<void*>( buffer );
+    Ogre::TextureBox dstBox( width, height, 1u, 1u, 0, 0, 0 );
+
+    if ( pixel_format == CEGUI::Texture::PixelFormat::Rgb )
+    {
+        // We need to expand the 24bpp RGB texture to 32bpp RGBA.
+        // This is because OGRE 2.2 no longer supports RGB
+        PixelFormatGpu ogrePixelFormatDst = toOgrePixelFormat(CEGUI::Texture::PixelFormat::Rgba);
+
+        dstBox.bytesPerPixel = Ogre::PixelFormatGpuUtils::getBytesPerPixel(ogrePixelFormatDst);
+        dstBox.bytesPerRow   = dstBox.bytesPerPixel * width;
+        dstBox.bytesPerImage = dstBox.bytesPerRow * height;
+        dstBox.data = new char[dstBox.bytesPerImage];
+
+        Ogre::PixelFormatGpuUtils::bulkPixelConversion(
+            srcBox, ogrePixelFormat,
+            dstBox, ogrePixelFormatDst
+        );
+        ogrePixelFormat = ogrePixelFormatDst;
+    }
+
+    createOgreTexture(ogrePixelFormat, width, height);
+
+    // schedule texture to be transitioned to the gpu
+    d_texture->_transitionTo(Ogre::GpuResidency::Resident, nullptr);
+    d_texture->_setNextResidencyStatus(Ogre::GpuResidency::Resident);
+
+    // build a staging texture that we'll use to upload into.
+    Ogre::TextureGpuManager *textureMgr = Ogre::Root::getSingletonPtr()->getRenderSystem()->getTextureGpuManager();
+    StagingTexture* stagingTexture = textureMgr->getStagingTexture(width, height, 1u, 1u, ogrePixelFormat);
+
+    // map a region and copy data into it
+    stagingTexture->startMapRegion();
+    TextureBox box = stagingTexture->mapRegion(width, height, 1u, 1u, ogrePixelFormat);
+    if ( pixel_format == CEGUI::Texture::PixelFormat::Rgb )
+        box.copyFrom(dstBox);
+    else
+        box.copyFrom(srcBox);
+    stagingTexture->stopMapRegion();
+
+    // trigger upload to the gpu in the defined texture.
+    stagingTexture->upload(box, d_texture, 0, nullptr, nullptr, true);
+
+    if (dstBox.data)
+        delete static_cast<char*>(dstBox.data);
+
+    // remove the staging texture and notify that the texture is finished
+    textureMgr->removeStagingTexture(stagingTexture);
+#else
     const size_t byte_size = calculateDataSize(buffer_size, pixel_format);
 
     char* bufferCopy = new char[byte_size];
@@ -226,6 +335,7 @@ void OgreTexture::loadFromMemory(const void* buffer, const Sizef& buffer_size,
     d_texture->setDepth(1);
     d_texture->createInternalResources();
     d_texture->getBuffer(0,0).get()->blitFromMemory(*pixelBox);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
     // throw exception if no texture was able to be created
     if (OGRE_ISNULL(d_texture))
@@ -260,6 +370,38 @@ void OgreTexture::blitFromMemory(const void* sourceData, const Rectf& area)
     }
 
 
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    Ogre::uint32 width = static_cast<Ogre::uint32>(area.getWidth());
+    Ogre::uint32 height = static_cast<Ogre::uint32>(area.getHeight());
+
+    size_t bytesPerPixel = Ogre::PixelFormatGpuUtils::getBytesPerPixel(d_texture->getPixelFormat());
+    size_t bytesPerRow = bytesPerPixel * width;
+
+    // acquire a staging texture
+    Ogre::TextureGpuManager *textureMgr = Ogre::Root::getSingletonPtr()->getRenderSystem()->getTextureGpuManager();
+    Ogre::StagingTexture *stagingTexture = textureMgr->getStagingTexture(
+            width, height, 1u, 1u, d_texture->getPixelFormat());
+
+    // setup the map region that we'll copy to
+    stagingTexture->startMapRegion();
+    Ogre::TextureBox box = stagingTexture->mapRegion( width, height, 1u, 1u, d_texture->getPixelFormat());
+    box.copyFrom(const_cast<void*>( sourceData ), width, height, bytesPerRow);
+    stagingTexture->stopMapRegion();
+
+    // upload the data to the gpu
+    // We specify a destination area based on the area rect provided as we may
+    // only want to upload a portion to the GPU texture area and not the entire thing.
+
+    Ogre::TextureBox dst;
+    dst.x = static_cast<Ogre::uint32>( area.left() );
+    dst.y = static_cast<Ogre::uint32>( area.top() );
+    dst.width = width;
+    dst.height = height;
+    stagingTexture->upload( box, d_texture, 0, nullptr, &dst );
+
+    // remove the staging texture and notify texture is prepared
+    textureMgr->removeStagingTexture( stagingTexture );
+#else
     // NOTE: const_cast because Ogre takes pointer to non-const here. Rather
     // than allow that to dictate poor choices in our own APIs, we choose to
     // address the issue as close to the source of the problem as possible.
@@ -273,6 +415,7 @@ void OgreTexture::blitFromMemory(const void* sourceData, const Rectf& area)
 			      static_cast<Ogre::uint32>(area.right()),
 			      static_cast<Ogre::uint32>(area.bottom()) );
     d_texture->getBuffer()->blitFromMemory(pb, box);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 }
 
 //----------------------------------------------------------------------------//
@@ -281,18 +424,31 @@ void OgreTexture::blitToMemory(void* targetData)
     if (OGRE_ISNULL(d_texture)) // TODO: exception?
         return;
 
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    throw RendererException("Unimplemented: blitToMemory for Ogre >= 2.2");
+#else
     Ogre::PixelBox pb(static_cast<std::uint32_t>(d_size.d_width), static_cast<std::uint32_t>(d_size.d_height),
                       1, d_texture->getFormat(), targetData);
     d_texture->getBuffer()->blitToMemory(pb);
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 }
 
 //----------------------------------------------------------------------------//
 void OgreTexture::freeOgreTexture()
 {
-    if (!OGRE_ISNULL(d_texture) && !d_isLinked)
+    if (!OGRE_ISNULL(d_texture) && !d_isLinked) {
+        #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+        Ogre::Root::getSingletonPtr()->getRenderSystem()->getTextureGpuManager()->destroyTexture(d_texture);
+        #else
         Ogre::TextureManager::getSingleton().remove(d_texture->getHandle());
+        #endif // CEGUI_USE_OGRE_TEXTURE_GPU
+    }
 
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+    d_texture = 0;
+    #else
     OGRE_RESET(d_texture);
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
 }
 
 //----------------------------------------------------------------------------//
@@ -341,8 +497,13 @@ void OgreTexture::updateCachedScaleValues()
 }
 
 //----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+void OgreTexture::setOgreTexture(Ogre::TextureGpu* texture, bool take_ownership)
+#else
 void OgreTexture::setOgreTexture(Ogre::TexturePtr texture, bool take_ownership)
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 {
+
     freeOgreTexture();
 
     d_texture = texture;
@@ -361,9 +522,22 @@ void OgreTexture::setOgreTexture(Ogre::TexturePtr texture, bool take_ownership)
 }
 
 //----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+Ogre::TextureGpu* OgreTexture::getOgreTexture() const
+{
+    return d_texture;
+}
+#else
 Ogre::TexturePtr OgreTexture::getOgreTexture() const
 {
     return d_texture;
+}
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
+
+//----------------------------------------------------------------------------//
+bool OgreTexture::textureIsLinked() const
+{
+    return d_isLinked;
 }
 
 //----------------------------------------------------------------------------//
@@ -371,10 +545,15 @@ bool OgreTexture::isPixelFormatSupported(const PixelFormat fmt) const
 {
     try
     {
+    #ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+        OgreTexture::toOgrePixelFormat(fmt);
+        return true;
+    #else
         return Ogre::TextureManager::getSingleton().
             isEquivalentFormatSupported(Ogre::TEX_TYPE_2D,
                                         toOgrePixelFormat(fmt),
                                         Ogre::TU_DEFAULT);
+    #endif // CEGUI_USE_OGRE_TEXTURE_GPU
     }
     catch (InvalidRequestException&)
     {
@@ -383,6 +562,58 @@ bool OgreTexture::isPixelFormatSupported(const PixelFormat fmt) const
 }
 
 //----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+Ogre::PixelFormatGpu OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
+{
+    switch (fmt)
+    {
+        case Texture::PixelFormat::Rgba:      return Ogre::PFG_RGBA8_UNORM;
+        case Texture::PixelFormat::Rgb:       return Ogre::PFG_RGB8_UNORM;
+        case Texture::PixelFormat::Rgb565:    return Ogre::PFG_B5G6R5_UNORM;
+        case Texture::PixelFormat::Rgba4444:  return Ogre::PFG_B4G4R4A4_UNORM;
+        case Texture::PixelFormat::Pvrtc2:    return Ogre::PFG_PVRTC_RGBA2;
+        case Texture::PixelFormat::Pvrtc4:    return Ogre::PFG_PVRTC_RGBA4;
+        case Texture::PixelFormat::RgbaDxt1:  return Ogre::PFG_BC1_UNORM;
+        case Texture::PixelFormat::RgbaDxt3:  return Ogre::PFG_BC2_UNORM;
+        case Texture::PixelFormat::RgbaDxt5:  return Ogre::PFG_BC3_UNORM;
+
+        default:
+            throw InvalidRequestException(
+                "Invalid pixel format translation.");
+    }
+}
+
+//----------------------------------------------------------------------------//
+Texture::PixelFormat OgreTexture::fromOgrePixelFormat(
+                                            const Ogre::PixelFormatGpu fmt)
+{
+    switch (fmt)
+    {
+        case Ogre::PFG_RGBA8_UNORM:       return Texture::PixelFormat::Rgba;
+        case Ogre::PFG_RGBA8_UNORM_SRGB:  return Texture::PixelFormat::Rgba;
+        case Ogre::PFG_BGRA8_UNORM:       return Texture::PixelFormat::Rgba;
+        case Ogre::PFG_BGRA8_UNORM_SRGB:  return Texture::PixelFormat::Rgba;
+        case Ogre::PFG_RGB8_UNORM:        return Texture::PixelFormat::Rgb;
+        case Ogre::PFG_RGB8_UNORM_SRGB:   return Texture::PixelFormat::Rgb;
+        case Ogre::PFG_BGR8_UNORM:        return Texture::PixelFormat::Rgb;
+        case Ogre::PFG_BGR8_UNORM_SRGB:   return Texture::PixelFormat::Rgb;
+        case Ogre::PFG_B5G6R5_UNORM:      return Texture::PixelFormat::Rgb565;
+        case Ogre::PFG_B4G4R4A4_UNORM:    return Texture::PixelFormat::Rgba4444;
+        case Ogre::PFG_PVRTC_RGBA2:       return Texture::PixelFormat::Pvrtc2;
+        case Ogre::PFG_PVRTC_RGBA4:       return Texture::PixelFormat::Pvrtc4;
+        case Ogre::PFG_BC1_UNORM:         return Texture::PixelFormat::RgbaDxt1;
+        case Ogre::PFG_BC1_UNORM_SRGB:    return Texture::PixelFormat::RgbaDxt1;
+        case Ogre::PFG_BC2_UNORM:         return Texture::PixelFormat::RgbaDxt3;
+        case Ogre::PFG_BC2_UNORM_SRGB:    return Texture::PixelFormat::RgbaDxt3;
+        case Ogre::PFG_BC3_UNORM:         return Texture::PixelFormat::RgbaDxt5;
+        case Ogre::PFG_BC3_UNORM_SRGB:    return Texture::PixelFormat::RgbaDxt5;
+
+        default:
+            throw InvalidRequestException(
+                "Invalid pixel format translation.");
+    }
+}
+#else
 Ogre::PixelFormat OgreTexture::toOgrePixelFormat(const Texture::PixelFormat fmt)
 {
     switch (fmt)
@@ -426,8 +657,28 @@ Texture::PixelFormat OgreTexture::fromOgrePixelFormat(
                 "Invalid pixel format translation.");
     }
 }
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 //----------------------------------------------------------------------------//
+#ifdef CEGUI_USE_OGRE_TEXTURE_GPU
+void OgreTexture::createOgreTexture(
+    Ogre::PixelFormatGpu pixel_format,
+    std::uint32_t width, std::uint32_t height,
+    Ogre::GpuPageOutStrategy::GpuPageOutStrategy pageOutStrategy
+) {
+    Ogre::TextureGpuManager *textureMgr = Ogre::Root::getSingletonPtr()->getRenderSystem()->getTextureGpuManager();
+    d_texture = textureMgr->createOrRetrieveTexture(
+                                    getUniqueName(),
+                                    pageOutStrategy,
+                                    Ogre::TextureFlags::ManualTexture,
+                                    Ogre::TextureTypes::Type2D,
+                                    Ogre::BLANKSTRING,
+                                    0u );
+    d_texture->setPixelFormat(pixel_format);
+    d_texture->setNumMipmaps(1u);
+    d_texture->setResolution(width, height);
+}
+#else
 void OgreTexture::createEmptyOgreTexture(PixelFormat pixel_format)
 {
     // try to create a Ogre::Texture with given dimensions
@@ -436,6 +687,7 @@ void OgreTexture::createEmptyOgreTexture(PixelFormat pixel_format)
         1, 1, 0,
         toOgrePixelFormat(pixel_format));
 }
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU
 
 
 //----------------------------------------------------------------------------//

--- a/cegui/src/RendererModules/Ogre/TextureTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/TextureTarget.cpp
@@ -24,6 +24,10 @@
  *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
+
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#ifndef CEGUI_USE_OGRE_TEXTURE_GPU
+
 #include "CEGUI/RendererModules/Ogre/TextureTarget.h"
 #include "CEGUI/RendererModules/Ogre/Texture.h"
 #include "CEGUI/PropertyHelper.h"
@@ -156,3 +160,4 @@ template class CEGUI::OgreRenderTarget<CEGUI::TextureTarget>;
 
 #endif
 
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU

--- a/cegui/src/RendererModules/Ogre/WindowTarget.cpp
+++ b/cegui/src/RendererModules/Ogre/WindowTarget.cpp
@@ -24,6 +24,10 @@
  *   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  *   OTHER DEALINGS IN THE SOFTWARE.
  ***************************************************************************/
+
+#include "CEGUI/RendererModules/Ogre/Renderer.h"
+#ifndef CEGUI_USE_OGRE_TEXTURE_GPU
+
 #include "CEGUI/RendererModules/Ogre/WindowTarget.h"
 
 #include <OgreRenderTarget.h>
@@ -79,4 +83,4 @@ void OgreWindowTarget::initRenderTarget(Ogre::RenderTarget& target)
 
 } // End of  CEGUI namespace section
 
-
+#endif // CEGUI_USE_OGRE_TEXTURE_GPU


### PR DESCRIPTION
port Ogre Renderer to Ogre 2.3 (new texture API)

* use CEGUI_USE_OGRE_TEXTURE_GPU macro
* use new OgreRenderTextureTarget class (instead of OgreRenderTarget, OgreTextureTarget and OgreWindowTarget)
* partially based on old Ogre 2.2 port by crancran: https://forums.ogre3d.org/viewtopic.php?f=25&t=82911&start=75
* tested rendering to main window and to texture