### PR TITLE
Disconnect before moving into the d_connection

### DIFF
--- a/cegui/include/CEGUI/Event.h
+++ b/cegui/include/CEGUI/Event.h
@@ -125,12 +125,14 @@ public:
 
         ScopedConnection& operator=(Event::Connection&& connection)
         {
+            disconnect();
             d_connection = std::move(connection);
             return *this;
         }
 
         ScopedConnection& operator=(ScopedConnection&& other) noexcept
         {
+            disconnect();
             d_connection = std::move(other.d_connection);
             return *this;
         }


### PR DESCRIPTION
This fixes an interesting crash where the DragContainer::d_targetDestroyConnection lambda is called (with random other windows) after it was already destroyed a long time ago. Seems other windows EventDestructionStarted triggered it (heap memory corruption? no clue :D)

Happened under VS 2019 (16.11.9)