### PR TITLE
v0.8 branch: OGRE: Fix build with OGRE 13.x

### DIFF
--- a/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
+++ b/cegui/include/CEGUI/RendererModules/Ogre/Renderer.h
@@ -64,13 +64,13 @@ typedef SharedPtr<Texture> TexturePtr;
 class Matrix4;
 }
 
-#if (CEGUI_OGRE_VERSION >= (2 << 16))
+#if (CEGUI_OGRE_VERSION >= (2 << 16)) && (CEGUI_OGRE_VERSION < (13 << 16))
 // The new Ogre Compositor2 system has to be used since ViewPorts 
 // no longer have the required functionality
 #define CEGUI_USE_OGRE_COMPOSITOR2
 #endif
 
-#if (CEGUI_OGRE_VERSION >= ((2 << 16) | (1 << 8) | 0))
+#if (CEGUI_OGRE_VERSION >= ((2 << 16) | (1 << 8) | 0))  && (CEGUI_OGRE_VERSION < (13 << 16))
 // The HLMS has to be used since fixed pipeline is disabled
 #define CEGUI_USE_OGRE_HLMS
 #include <OgreRenderOperation.h>

--- a/cegui/src/RendererModules/Ogre/Texture.cpp
+++ b/cegui/src/RendererModules/Ogre/Texture.cpp
@@ -32,6 +32,9 @@
 #include <OgreTextureManager.h>
 #include <OgreHardwarePixelBuffer.h>
 
+// Fixing https://github.com/OGRECave/ogre/issues/2424
+#include <sstream>
+
 // Start of CEGUI namespace section
 namespace CEGUI
 {

--- a/samples_framework/src/CEGuiOgreBaseApplication.cpp
+++ b/samples_framework/src/CEGuiOgreBaseApplication.cpp
@@ -80,12 +80,23 @@ CEGuiOgreBaseApplication::CEGuiOgreBaseApplication() :
 
         // Create the scene manager
         SceneManager* sm = d_ogreRoot->
+#if (OGRE_VERSION >= ((13 << 16)))
+            createSceneManager(DefaultSceneManagerFactory::FACTORY_TYPE_NAME, "SampleSceneMgr");
+
+        SceneNode* camNode = sm->getRootSceneNode()->createChildSceneNode();
+        d_camera = sm->createCamera("SampleCam");
+        camNode->setPosition(0,0,500);
+        camNode->lookAt(Vector3(0,0,-300), Node::TransformSpace::TS_WORLD);
+        d_camera->setNearClipDistance(5);
+        camNode->attachObject(d_camera);
+#else
             createSceneManager(ST_GENERIC, "SampleSceneMgr");
         // Create and initialise the camera
         d_camera = sm->createCamera("SampleCam");
         d_camera->setPosition(Vector3(0,0,500));
         d_camera->lookAt(Vector3(0,0,-300));
         d_camera->setNearClipDistance(5);
+#endif
 
         // Create a viewport covering whole window
         Viewport* vp = d_window->addViewport(d_camera);
@@ -389,8 +400,11 @@ CEGuiDemoFrameListener::CEGuiDemoFrameListener(CEGuiOgreBaseApplication* baseApp
 
         unsigned int width, height, depth;
         int left, top;
-
+#if (OGRE_VERSION >= (13 << 16))
+        window->getMetrics(width, height, left, top);
+#else
         window->getMetrics(width, height, depth, left, top);
+#endif
         const OIS::MouseState& mouseState = d_mouse->getMouseState();
         mouseState.width = width;
         mouseState.height = height;


### PR DESCRIPTION
Do not use some deprecated functions as the node-less positioning API disabled by default.

I have not tested the master branch so maybe you want to port it to master too.