### PR TITLE
Stopping crash on exit with Ogre after setting default cursor image

### DIFF
--- a/cegui/src/RendererModules/Ogre/Renderer.cpp
+++ b/cegui/src/RendererModules/Ogre/Renderer.cpp
@@ -895,6 +895,7 @@ OgreRenderer::~OgreRenderer()
     clearVertexBufferPool();
 
     delete d_pimpl;
+    d_pimpl = NULL;
 }
 
 //----------------------------------------------------------------------------//
@@ -1707,7 +1708,12 @@ UsedOgreHWBuffer OgreRenderer::getVertexBuffer(size_t
 void OgreRenderer::returnVertexBuffer(UsedOgreHWBuffer
     buffer)
 {
-    d_pimpl->d_vbPool.push_back(buffer);
+    //If d_pimpl is null this has been called via the destructor so
+    //no need to cache 
+    if (d_pimpl)
+        d_pimpl->d_vbPool.push_back(buffer);
+    else
+        buffer.reset();
 }
 
 void OgreRenderer::clearVertexBufferPool()


### PR DESCRIPTION
The destructor for CEGUI Renderer results in the Ogre Renderer trying to cache a UsedOgreHWBuffer but the Ogre Rendering impl has already been destroyed. The PR checks to see if the impl has been destroyed before trying to insert into the cache.