### PR TITLE
Fix for issue: https://github.com/cegui/cegui/issues/1287

### DIFF
--- a/cegui/src/widgets/Combobox.cpp
+++ b/cegui/src/widgets/Combobox.cpp
@@ -588,7 +588,7 @@ bool Combobox::editbox_PointerPressHoldHandler(const EventArgs& e)
         return false;
 
     Editbox* editbox = getEditbox();
-    if (editbox->isReadOnly())
+    if (!editbox->isReadOnly())
         return false;
 
     ComboDropList* droplist = getDropList();


### PR DESCRIPTION
Combo-box: if has set ReadOnly=true then click to editbox should show drop list #1287 In the older CEGUI version, I had set ReadOnly property to true on the combo-box and when I clicked on to edit-box (not to icon button for showing the drop list) the drop list was opened. Now it doesn't work and even edit-box selection is possible... It looks like logic has swapped...