### PR TITLE
Editbox: changing masking mode doesn't work

### DIFF
--- a/cegui/src/widgets/Combobox.cpp
+++ b/cegui/src/widgets/Combobox.cpp
@@ -588,7 +588,7 @@ bool Combobox::editbox_PointerPressHoldHandler(const EventArgs& e)
         return false;
 
     Editbox* editbox = getEditbox();
-    if (editbox->isReadOnly())
+    if (!editbox->isReadOnly())
         return false;
 
     ComboDropList* droplist = getDropList();

--- a/cegui/src/widgets/EditboxBase.cpp
+++ b/cegui/src/widgets/EditboxBase.cpp
@@ -168,7 +168,7 @@ void EditboxBase::setTextMaskingEnabled(bool setting)
 
     d_textMaskingEnabled = setting;
 
-    d_renderedTextDirty = false;
+    d_renderedTextDirty = true;
     invalidate();
 
     WindowEventArgs args(this);


### PR DESCRIPTION
Fixed bug: if you changed masking mode for edit-box by clicking on some button and calling EditboxBase::setTextMaskingEnabled() the text in editbox wasn't changed from normal text to asterisks"****" and vice versa. Couse is that d_renderedTextDirty in this method was set to false and tot to true so text wasn't updated in rendering.