### PR TITLE
Combobox crash: if combobox is expanded and you use 2x ESC for closing sample browser 

### DIFF
--- a/cegui/src/widgets/Combobox.cpp
+++ b/cegui/src/widgets/Combobox.cpp
@@ -588,7 +588,7 @@ bool Combobox::editbox_PointerPressHoldHandler(const EventArgs& e)
         return false;
 
     Editbox* editbox = getEditbox();
-    if (editbox->isReadOnly())
+    if (!editbox->isReadOnly())
         return false;
 
     ComboDropList* droplist = getDropList();

--- a/cegui/src/widgets/Combobox.cpp
+++ b/cegui/src/widgets/Combobox.cpp
@@ -449,7 +449,10 @@ void Combobox::onDropListDisplayed(WindowEventArgs& e)
 //----------------------------------------------------------------------------//
 void Combobox::onDroplistRemoved(WindowEventArgs& e)
 {
-    getGUIContext().updateWindowContainingCursor();
+    GUIContext* pContext = getGUIContextPtr();
+    if (pContext)
+        pContext->updateWindowContainingCursor();
+
     getPushButton()->setPushedState(false);
 	fireEvent(EventDropListRemoved, e, EventNamespace);
 }


### PR DESCRIPTION
GUIContext is null if you remove/hide screen and children. So if you have expanded combo-box and you pressed ESC there was crash in CEGUI -> Combobox::onDroplistRemoved(WindowEventArgs& e).

This is my proposal fix for issue: https://github.com/cegui/cegui/issues/1298
