### PR TITLE
Fix return type of xmlGetLastError for libxml2 2.12

### DIFF
--- a/cegui/src/XMLParserModules/Libxml2/XMLParser.cpp
+++ b/cegui/src/XMLParserModules/Libxml2/XMLParser.cpp
@@ -109,7 +109,11 @@ void LibxmlParser::parseXML(XMLHandler& handler,
 
     if (!doc)
     {
+#if LIBXML_VERSION >= 21200
+        const xmlError* err = xmlGetLastError();
+#else
         xmlError* err = xmlGetLastError();
+#endif
 
         throw GenericException(
             String("xmlParseMemory failed in file: '") +


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7