### PR TITLE
Fix: Crash when trying to paste non-text clipboard data

### DIFF
--- a/cegui/src/Clipboard.cpp
+++ b/cegui/src/Clipboard.cpp
@@ -101,8 +101,8 @@ void Clipboard::getData(String& mimeType, const void*& buffer, size_t& size)
     // (if possible)
     if (d_nativeProvider)
     {
-        size_t retrievedSize;
-        void* retrievedBuffer;
+        size_t retrievedSize = 0;
+        void* retrievedBuffer = nullptr;
         
         d_nativeProvider->retrieveFromClipboard(d_mimeType, retrievedBuffer, retrievedSize);
         


### PR DESCRIPTION
When GetClipboardData(CF_UNICODETEXT) fails we read from an uninitialized size_t retrievedSize