### PR TITLE
Remove redundant scrollbar visibility changes and fix thumb dragging state is lost

### DIFF
--- a/cegui/include/CEGUI/WindowRendererSets/Core/StaticText.h
+++ b/cegui/include/CEGUI/WindowRendererSets/Core/StaticText.h
@@ -575,7 +575,9 @@ private:
     Scrollbar* getVertScrollbarWithoutUpdate() const;
     Scrollbar* getHorzScrollbarWithoutUpdate() const;
     Rectf getTextRenderAreaWithoutUpdate() const;
+    Rectf getTextRenderAreaWithoutUpdate(bool withVertScrollbar, bool withHorzScrollbar) const;
     const ComponentArea& getTextComponentAreaWithoutUpdate() const;
+    const ComponentArea& getTextComponentAreaWithoutUpdate(bool withVertScrollbar, bool withHorzScrollbar) const;
     const Sizef& getTextExtentWithoutUpdate() const;
     void adjustSizeToContent_wordWrap_keepingAspectRatio(const Sizef& contentMaxSize,
         USize& size_func, float window_max_width, float epsilon);


### PR DESCRIPTION
The thumb dragging state is lost when the scrollbar is temporarily hidden e.g. when the text changes.

You can squash and merge :D