### PR TITLE
Fix: Tooltips stop displaying text in some higher resolutions because the initial size becomes negative

### DIFF
--- a/cegui/src/text/RenderedText.cpp
+++ b/cegui/src/text/RenderedText.cpp
@@ -396,7 +396,7 @@ void RenderedText::updateDynamicObjectExtents(const Window* hostWindow)
 bool RenderedText::updateFormatting(float areaWidth)
 {
     if (areaWidth < 0.f)
-        return false;
+        areaWidth = 0.f;
 
     const bool areaWidthChanged = (d_areaWidth != areaWidth);
     d_areaWidth = areaWidth;


### PR DESCRIPTION
like 3200x1800